### PR TITLE
408 fix scroll after login

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -61,6 +61,8 @@
     },
     methods: {
       onLogin () {
+        window.document.body.style.overflow = 'visible'
+        
         if (this.$store.getters.routeBeforeRedirect) {
           this.$router.push({name: this.$store.getters.routeBeforeRedirect})
         } else {

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -61,8 +61,12 @@
     },
     methods: {
       onLogin () {
+        // Set the body overflow to visible because the login modal set it to 'hidden'.
+        // After login, the index route is pushed to view router and the body overflow is
+        // not set to his original state
+        // see src/components/Materialize/Modale.vue#62
         window.document.body.style.overflow = 'visible'
-        
+
         if (this.$store.getters.routeBeforeRedirect) {
           this.$router.push({name: this.$store.getters.routeBeforeRedirect})
         } else {


### PR DESCRIPTION
## What does this PR do ?

After login, the `body` has the style `overflow: hidden` and it was impossible to scroll over large number of index.  

Fix: #408 

### How should this be manually tested?

  - Step 1: create a lot of index `for i in {1..40}; do; curl -X POST "http://localhost:7512/test$i/_create"; sleep 0.1; done`
  - Step 2: Open the admin console and then logout
  - Step 3: Log as anonymous, you should be able to scroll over the index list  