### PR TITLE
Shrinked the main wrapper a little bit and centered it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2371,7 +2371,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2786,7 +2787,8 @@
             "safe-buffer": {
               "version": "5.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -2842,6 +2844,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -2885,12 +2888,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -96,8 +96,11 @@ h6 {
 
 main {
   padding-left: $sidebar-width;
+
   .wrapper {
     padding: 20px;
+    max-width: 1080px;
+    margin: auto;
   }
 }
 


### PR DESCRIPTION
## What does this PR do ?
This PR introduces a layout proposal for the content pane of the Admin Console. It's just a proposal and I'd like to ask the community for feedback.

### Motivation
Working on the Admin Console on large screens is annoying to me due to the item lists taking the whole screen width. I found that list items don't need all that space, since content is mostly vertically laid out and takes one fifth of the screen width at most (when the item content is expanded).
Plus, this layout makes it painful to reach the action buttons for items (the little pencil and the "Delete" menu item).
And, last but not least, it simply looked ugly to my eyes. Not that I find this new layout particularly pretty, but it seems to me it's on the right track.

### How should this be manually tested?
Open the Netlify-deployed instance or build your own locally and connect it to a running Kuzzle Server. Just browse the documents of a collection or the Security section and see how it looks. You can also play with the window width and see how it behaves.

### Screenshots

#### Before
![kuzzle admin console - mozilla firefox_117](https://user-images.githubusercontent.com/5023426/44514496-93e52600-a6c0-11e8-86c4-469645a62b07.png)

#### After
![kuzzle admin console - mozilla firefox_118](https://user-images.githubusercontent.com/5023426/44514549-b5dea880-a6c0-11e8-945f-963507a49207.png)
