### PR TITLE
Remember list view type

### DIFF
--- a/src/components/Data/Documents/ListViewButtons.vue
+++ b/src/components/Data/Documents/ListViewButtons.vue
@@ -8,13 +8,13 @@
       class="ListViewButtons-btn fa fa-th"
       :class="{disabled: !boxesEnabled, active: activeView === 'boxes'}"
       :title="boxesEnabled ? 'Display this list as boxes' : ''"
-      @click="$emit('boxes')"
+      @click="onBoxesClicked"
       >
     </a>
     <a
       class="ListViewButtons-btn fa fa-map-marked"
       :class="{disabled: !mapEnabled, active: activeView === 'map'}"
-      @click="$emit('map')"
+      @click="onMapClicked"
       >
     </a>
   </div>
@@ -22,6 +22,7 @@
 
 <script>
 export default {
+  name: 'ListViewButtons',
   props: {
     activeView: {
       type: String,
@@ -37,6 +38,20 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    }
+  },
+  methods: {
+    onBoxesClicked() {
+      if (!this.boxesEnabled) {
+        return
+      }
+      this.$emit('boxes')
+    },
+    onMapClicked() {
+      if (!this.mapEnabled) {
+        return
+      }
+      this.$emit('map')
     }
   }
 }

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -42,7 +42,7 @@
           </div>
           <div class="col s2">
             <list-view-buttons
-              :active-view="listViewType"
+              :active-view="currentFilter.listViewType"
               :boxes-enabled="true"
               :map-enabled="isCollectionGeo"
               @list="onListViewClicked"
@@ -70,7 +70,7 @@
 
         <div class="row" v-show="documents.length">
 
-          <div class="col s12" v-show="listViewType === 'list'">
+          <div class="col s12" v-show="currentFilter.listViewType === 'list'">
             <div class="collection">
               <div class="collection-item collection-transition" v-for="document in documents" :key="document.id">
                 <document-item
@@ -99,13 +99,13 @@
             </div>
           </div>
 
-          <div class="DocumentList-boxes col s12" v-show="listViewType === 'boxes'">
+          <div class="DocumentList-boxes col s12" v-show="currentFilter.listViewType === 'boxes'">
             <i class="fa fa-th fa-5x"></i>
             <h2>Boxes List view</h2>
             <p>This feature is not yet implemented.</p>
             <p>Hold on, we'll ship it soon!</p>
           </div>
-          <div class="DocumentList-map col s12" v-show="listViewType === 'map'">
+          <div class="DocumentList-map col s12" v-show="currentFilter.listViewType === 'map'">
             <i class="fa fa-map-marked fa-5x"></i>
             <h2>Map List view</h2>
             <p>This feature is not yet implemented.</p>
@@ -181,7 +181,6 @@ export default {
   },
   data() {
     return {
-      listViewType: 'list',
       searchFilterOperands: filterManager.searchFilterOperands,
       selectedDocuments: [],
       documents: [],
@@ -394,13 +393,25 @@ export default {
     // LIST VIEW TYPES
     // =====================================================
     onListViewClicked() {
-      this.listViewType = 'list'
+      this.onFiltersUpdated(
+        Object.assign(this.currentFilter, {
+          listViewType: filterManager.LIST_VIEW_LIST
+        })
+      )
     },
     onBoxesViewClicked() {
-      this.listViewType = 'boxes'
+      this.onFiltersUpdated(
+        Object.assign(this.currentFilter, {
+          listViewType: filterManager.LIST_VIEW_BOXES
+        })
+      )
     },
     onMapViewClicked() {
-      this.listViewType = 'map'
+      this.onFiltersUpdated(
+        Object.assign(this.currentFilter, {
+          listViewType: filterManager.LIST_VIEW_MAP
+        })
+      )
     }
   },
   mounted() {

--- a/src/services/filterManager.js
+++ b/src/services/filterManager.js
@@ -148,6 +148,9 @@ export const ACTIVE_RAW = 'raw'
 export const SORT_ASC = 'asc'
 export const SORT_DESC = 'desc'
 export const DEFAULT_QUICK = ''
+export const LIST_VIEW_LIST = 'list'
+export const LIST_VIEW_BOXES = 'boxes'
+export const LIST_VIEW_MAP = 'map'
 
 export function Filter() {
   this.active = NO_ACTIVE
@@ -156,6 +159,7 @@ export function Filter() {
   this.raw = null
   this.sorting = null
   this.from = 0
+  this.listViewType = LIST_VIEW_LIST
 }
 
 export const searchFilterOperands = {


### PR DESCRIPTION
## What does this PR do ?
This PR enables a document collection to remember the list view type across page reloads and navigation, just like filters.

### How should this be manually tested?
* Browse to a collection and change its list view type.
* Browse to another collection (or create a document)
* Go back to the collection page: the list view type sticks to the last you selected.

## Other changes
Fixed bug that allowed to select a list view even if it was disabled.