### PR TITLE
Fixed JSON DocumentForm labels

### DIFF
--- a/src/components/Common/JsonForm/JsonForm.vue
+++ b/src/components/Common/JsonForm/JsonForm.vue
@@ -145,7 +145,8 @@ export default {
     label {
       top: 0.4rem;
       &.active {
-        transform: translateY(-120%);
+        transform: translateY(-20%);
+        font-size: 0.7em;
       }
     }
     .inline-actions {

--- a/src/components/Data/Documents/Common/CreateOrUpdate.vue
+++ b/src/components/Data/Documents/Common/CreateOrUpdate.vue
@@ -90,9 +90,6 @@
   }
 
   .json-view {
-    .card-content {
-      padding-top: 0;
-    }
     .document-json {
       .pre_ace,
       .ace_editor {

--- a/src/components/Data/Documents/Common/CreateOrUpdate.vue
+++ b/src/components/Data/Documents/Common/CreateOrUpdate.vue
@@ -85,6 +85,8 @@
 <style rel="stylesheet/scss" lang="scss">
 // @TODO format this code to BEM
 .DocumentCreateOrUpdate {
+  max-width: $container-width;
+
   form.wrapper {
     padding-top: 0;
   }

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -83,7 +83,7 @@
             <div class="row" v-show="documents.length">
 
               <div class="DocumentList-list col s12" v-show="currentFilter.listViewType === 'list'">
-                <div class="collection">
+                <div class="DocumentList-materializeCollection collection">
                   <div class="collection-item collection-transition" v-for="document in documents" :key="document.id">
                     <document-list-item
                       :document="document"
@@ -583,11 +583,9 @@ export default {
   margin-bottom: 0;
 }
 
-.DocumentList-boxes {
-  padding: 30px;
-
-  i {
-    color: $lavandia-color;
+.DocumentList-list {
+  .DocumentList-materializeCollection {
+    overflow: visible;
   }
 }
 


### PR DESCRIPTION
## What does this PR do ?
Just  a little fix to a bug that made the labels of the DocumentForm JSONForm translate too high when the text field was focused

### How should this be manually tested?

* Create a collection with a mapping and setup the document creation form
* Click on "Create Document"
* Focus a form field

### Other Changes

* Restored good padding in the Documents/CreateOrUpdate RawJSON page
* Fixed max width of document creation form
* Fixed bug with the overflow of the document dropdown in the document list

### Screenshots 

#### Before

![selection_129](https://user-images.githubusercontent.com/5023426/44858462-5eb57680-ac72-11e8-9a45-6021dcdb0797.png)

#### After

![selection_130](https://user-images.githubusercontent.com/5023426/44858584-a2a87b80-ac72-11e8-919e-b55b5a0240e6.png)

