### PR TITLE
Document cr friendly msg

### DIFF
--- a/src/components/Common/JsonForm/JsonForm.vue
+++ b/src/components/Common/JsonForm/JsonForm.vue
@@ -145,7 +145,8 @@ export default {
     label {
       top: 0.4rem;
       &.active {
-        transform: translateY(-120%);
+        transform: translateY(-20%);
+        font-size: 0.7em;
       }
     }
     .inline-actions {

--- a/src/components/Data/Documents/Common/CreateOrUpdate.vue
+++ b/src/components/Data/Documents/Common/CreateOrUpdate.vue
@@ -4,21 +4,7 @@
       <form class="wrapper" @submit.prevent="create">
 
         <div class="row" v-if="$store.state.collection.allowForm">
-          <div class="switch right">
-            <label>
-              Form
-              <input :disabled="warningSwitch" type="checkbox" @change="switchView" :checked="$store.state.collection.defaultViewJson">
-              <span
-                class="lever"
-                v-title="{
-                active: warningSwitch,
-                position: 'bottom',
-                title: 'You have unspecified custom attribute(s). Please edit the collection definition, or remove them.'
-                }">
-              </span>
-              JSON
-            </label>
-          </div>
+
         </div>
 
         <div class="row input-id" v-if="!hideId">
@@ -26,6 +12,35 @@
             <div class="input-field">
               <input id="id" type="text" name="collection" @input="updateId" v-focus :required="mandatoryId" />
               <label for="id">Document identifier {{!mandatoryId ? '(optional)' : ''}}</label>
+            </div>
+          </div>
+          <div class="col s6">
+
+            <div
+              class="switch right"
+              v-if="$store.state.collection.allowForm"
+              >
+              <label>
+                Form
+                <input :disabled="warningSwitch" type="checkbox" @change="switchView" :checked="$store.state.collection.defaultViewJson">
+                <span
+                  class="lever"
+                  v-title="{
+                  active: warningSwitch,
+                  position: 'bottom',
+                  title: 'You have unspecified custom attribute(s). Please edit the collection definition, or remove them.'
+                  }">
+                </span>
+                JSON
+              </label>
+            </div>
+
+            <div
+              v-if="!$store.state.collection.allowForm"
+              class="DocumentCreateOrUpdate-formDisabled"
+              >
+                <p>Document-creation form is not enabled for this collection</p>
+                <router-link :to="{name: 'DataCollectionEdit', params: {index, collection}}">Enable it</router-link>
             </div>
           </div>
         </div>
@@ -104,6 +119,16 @@
       }
     }
   }
+
+  .DocumentCreateOrUpdate-formDisabled {
+    float: right;
+    font-size: 0.9em;
+    font-weight: 800;
+    font-family: 'Courier New', Courier, monospace;
+    color: $grey-color;
+    text-align: right;
+  }
+
   .DocumentCreateOrUpdate-mapping {
     height: 500px;
     margin: 0;

--- a/src/components/Data/Documents/Common/CreateOrUpdate.vue
+++ b/src/components/Data/Documents/Common/CreateOrUpdate.vue
@@ -90,9 +90,6 @@
   }
 
   .json-view {
-    .card-content {
-      padding-top: 0;
-    }
     .document-json {
       .pre_ace,
       .ace_editor {


### PR DESCRIPTION
## What does this PR do ?
Added a message to help users understand they can set up a document creation form even when it's disabled because they put no mapping when the collection was created.

### How should this be manually tested?

* Create a collection with no mapping
* Create a document inside it
* check that the message in the screen-shoot appears and the link works correctly.

### Other changes

### Boyscout

### Screenshots (if appropriate)

![screenshot_2018-08-30 kuzzle admin console](https://user-images.githubusercontent.com/5023426/44863152-a0e3b580-ac7c-11e8-8f76-334c7563f3be.png)
