### PR TITLE
HOTFIXed pencil icon names after FontAwesome update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-admin-console",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-admin-console",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A handy administrative console for Kuzzle",
   "author": "The Kuzzle team <support@kuzzle.io>",
   "private": false,

--- a/src/components/Common/Environments/EnvironmentsSwitch.vue
+++ b/src/components/Common/Environments/EnvironmentsSwitch.vue
@@ -12,12 +12,12 @@
     </a>
 
     <ul :id='"environment-dropdown-" + _uid' class='dropdown-content environment-dropdown'>
-      <li v-for="(env, index) in $store.state.kuzzle.environments" class="environment">
+      <li v-for="(env, index) in $store.state.kuzzle.environments" :key="env.name" class="environment">
         <div @click="clickSwitch(index)">
           <span class="name environment-attribute truncate">{{env.name}}</span>
           <span class="host environment-attribute truncate">{{env.host}}</span>
         </div>
-        <i class="edit primary fa fa-pencil" @click.prevent="$emit('environment::create', index)"></i>
+        <i class="edit primary fa fa-pencil-alt" @click.prevent="$emit('environment::create', index)"></i>
         <i class="delete error fa fa-trash" @click.prevent="$emit('environment::delete', index)"></i>
       </li>
       <li class="divider"></li>

--- a/src/components/Data/Documents/DocumentBoxItem.vue
+++ b/src/components/Data/Documents/DocumentBoxItem.vue
@@ -111,6 +111,10 @@ export default {
     flex-wrap: nowrap;
     flex-direction: row;
 
+    .card-title {
+      flex-grow: 1;
+    }
+
     span {
       white-space: nowrap;
       overflow: hidden;

--- a/src/components/Data/Leftnav/IndexBranch.vue
+++ b/src/components/Data/Leftnav/IndexBranch.vue
@@ -74,18 +74,10 @@ export default {
       return []
     },
     orderedFilteredStoredCollections() {
-      return this.filteredStoredCollections
-        .map(obj => {
-          return this.highlight(obj, this.filter)
-        })
-        .sort()
+      return this.filteredStoredCollections.sort()
     },
     orderedFilteredRealtimeCollections() {
-      return this.filteredRealtimeCollections
-        .map(obj => {
-          return this.highlight(obj, this.filter)
-        })
-        .sort()
+      return this.filteredRealtimeCollections.sort()
     }
   },
   methods: {

--- a/src/components/Materialize/Dropdown.vue
+++ b/src/components/Materialize/Dropdown.vue
@@ -1,6 +1,5 @@
 <template>
   <span :cmylass="myclass">
-
     <a class="action dropdown-button fa fa-ellipsis-v" :data-activates="parsedId"></a>
 
     <ul :id="parsedId" class='dropdown-content'>
@@ -55,7 +54,7 @@ export default {
 
       let parsed = this.id + this._uid
 
-      return parsed.replace(/[!"#$%&'()*+,./:;<=>?@[\]^`{|}~ ]/g, '\\$&')
+      return parsed.replace(/[!"#$%&'()*+,./:;<=>?@[\]^`{|}~ ]/g, '-')
     }
   },
   mounted() {

--- a/src/components/Security/Profiles/ProfileItem.vue
+++ b/src/components/Security/Profiles/ProfileItem.vue
@@ -20,7 +20,7 @@
     <div class="ProfileItem-actions right">
       <a href="#" @click.prevent="update"
          v-title="{active: !canEditProfile(), title: 'You are not allowed to edit this profile'}">
-        <i class="fa fa-pencil" :class="{'disabled': !canEditProfile()}"></i>
+        <i class="fa fa-pencil-alt" :class="{'disabled': !canEditProfile()}"></i>
       </a>
       <dropdown :id="document.id" myclass="icon-black">
         <li><a @click="deleteDocument(document.id)"

--- a/src/components/Security/Roles/RoleItem.vue
+++ b/src/components/Security/Roles/RoleItem.vue
@@ -20,7 +20,7 @@
     <div class="RoleItem-actions right">
       <a href="#" @click.prevent="update"
           v-title="{active: !canEditRole(), title: 'You are not allowed to edit this role'}">
-          <i class="fa fa-pencil" :class="{'disabled': !canEditRole()}"></i>
+          <i class="fa fa-pencil-alt" :class="{'disabled': !canEditRole()}"></i>
       </a>
       <dropdown :id="document.id" myclass="icon-black">
         <li><a @click="deleteDocument(document.id)"


### PR DESCRIPTION
## What does this PR do ?
I forgot to change `fa-pencil` to `fa-pencil-alt` (after FontAwesome moved the former to the PRO version) in the `RoleItem` and `ProfileItem`.

### How should this be manually tested?
Try to edit a role or a profile from the list.

## Other changes

* Fixed See #437.
* Fixed the position of the dropdown menu in the DocumentBoxedItem
* More aggressively stripping garbage characters in the internal `:id` of Materialize Dropdown
