### PR TITLE
Fix search of nested geopoints

### DIFF
--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -67,7 +67,7 @@
               v-if="documents.length"
               :all-checked="allChecked"
               :display-bulk-delete="hasSelectedDocuments"
-              :mappingGeopoints="mappingGeopoints"
+              :geopointList="mappingGeopoints"
               :viewType="currentFilter.listViewType"
               :displayCreate="canCreateDocument(this.index, this.collection)"
               :displayGeopointSelect="currentFilter.listViewType === 'map'"
@@ -329,7 +329,7 @@ export default {
           if (properties.lat && properties.lon) {
             attributes = attributes.concat(path.concat(attributeName).join('.'))
           }
-          
+
           attributes = attributes.concat(
             this.listMappingGeopoints(properties, path.concat(attributeName))
           )

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -324,8 +324,16 @@ export default {
     listMappingGeopoints(mapping, path = []) {
       let attributes = []
 
-      for (const [attributeName, { type }] of Object.entries(mapping)) {
-        if (type === 'geo_point') {
+      for (const [attributeName, { type, properties }] of Object.entries(mapping)) {
+        if (properties) {
+          if (properties.lat && properties.lon) {
+            attributes = attributes.concat(path.concat(attributeName).join('.'))
+          }
+          
+          attributes = attributes.concat(
+            this.listMappingGeopoints(properties, path.concat(attributeName))
+          )
+        } else if (type === 'geo_point') {
           attributes = attributes.concat(path.concat(attributeName).join('.'))
         }
       }


### PR DESCRIPTION
## What does this PR do ?

For the map view, we are looking for a `geo_point` property in the document. But the function does not support nested `geo_point`.

This PR add support for nested `geo_point` detection. It also consider a property that have two nested properties called `lat` and `lon` as a geo compatible property.

In this example, both `home` and `work` properties are geo compatible properties:
```js
{
   home: { type: 'geo_point' },
   work: {
     properties: {
       lat: { type: 'long' },
       lon: { type: 'long' }
     }
}
```

### How should this be manually tested?

  - Step 1 : Use this [script](https://gist.github.com/Aschen/7825c8160cb9b7aaf7e1cc0e4ffa1197) to create some documents
  - Step 2 : Go to the map view and try to switch between `location` and `nested.emplacement`

### Other changes

 - Fix geo point selector
 - Update docker-compose