### PR TITLE
Fix usage of string for map coordinate

### DIFF
--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -244,8 +244,10 @@ export default {
     geoDocuments() {
       return this.documents.filter(document => {
         const [lat, lng] = this.getCoordinates(document)
+        const latFloat = parseFloat(lat)
+        const lngFloat = parseFloat(lng)
 
-        return lat && typeof lat === 'number' && lng && typeof lng === 'number'
+        return (!isNaN(latFloat) && !isNaN(lngFloat))
       })
     },
     latFieldPath() {


### PR DESCRIPTION

## What does this PR do ?
 
This PR allow the usage of string for `lat` and `lon` coordinates.

### How should this be manually tested?

Use this mapping:
```
{
  "location": {
    "type": "geo_point"
  },
  "name": {
    "type": "keyword"
  }
}
```

And this document:
```
{
 "name": "Aix TGV",
 "location": {
"lat": "43.45553",
"lon":"5.31663"
}
}
```

Then load the map view