### PR TITLE
Don't get non-existent credentials

### DIFF
--- a/src/components/Security/Users/Steps/CredentialsSelector.vue
+++ b/src/components/Security/Users/Steps/CredentialsSelector.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
-    <label></label>
+    <h5>Available strategies</h5>
+    <hr>
     <m-select v-model="currentStrategy">
       <option v-for="strategy in strategies">{{strategy}}</option>
     </m-select>

--- a/src/components/Security/Users/Steps/StepsContent.vue
+++ b/src/components/Security/Users/Steps/StepsContent.vue
@@ -118,10 +118,17 @@ export default {
 
         await Promise.all(
           this.strategies.map(async strategy => {
-            let strategyCredentials = await kuzzle.security.getCredentialsPromise(
+            const credentialsExists = await kuzzle.security.hasCredentialsPromise(strategy, this.kuid)
+
+            if (!credentialsExists) {
+              return
+            }
+
+            const strategyCredentials = await kuzzle.security.getCredentialsPromise(
               strategy,
               this.kuid
             )
+            
             if (strategyCredentials.kuid) {
               delete strategyCredentials.kuid
             }

--- a/src/components/Security/Users/Update.vue
+++ b/src/components/Security/Users/Update.vue
@@ -131,11 +131,21 @@ export default {
         await kuzzle.security.replaceUserPromise(this.user.kuid, userObject)
         await Promise.all(
           Object.keys(this.user.credentials).map(async strategy => {
-            await kuzzle.security.updateCredentialsPromise(
-              strategy,
-              this.user.kuid,
-              this.user.credentials[strategy]
-            )
+            const credentialsExists = await kuzzle.security.hasCredentialsPromise(strategy, this.user.kuid)
+
+            if (credentialsExists) {
+              await kuzzle.security.updateCredentialsPromise(
+                strategy,
+                this.user.kuid,
+                this.user.credentials[strategy]
+              )
+            } else {
+              await kuzzle.security.createCredentialsPromise(
+                strategy,
+                this.user.kuid,
+                this.user.credentials[strategy]
+              )
+            }
           })
         )
         await kuzzle.queryPromise(


### PR DESCRIPTION
## What does this PR do ?

When loading an user, we try to get credentials for all available strategy even if the user didn't register credentials for all strategies.  
This lead to errors that cause ambiguous errors message and unexpected side effects. 

Fix: https://github.com/kuzzleio/kuzzle-admin-console/issues/463 https://github.com/kuzzleio/kuzzle-admin-console/issues/364

### Other changes

 - Fix a bug that prevent to create credentials for a new strategy

### How should this be manually tested?

  - Step 1 : Setup a kuzzle stack with a working local and a working oauth strategy (good luck)
  - Step 2 : Create an user using your oauth strategy
  - Step 3 :  Update the local strategy or the facebook strategy
