### PR TITLE
KZL-581 Translate Basic search queries to Raw

### DIFF
--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -103,9 +103,7 @@
           class="BasicFilter-translateBtn btn waves-effect waves-light success right"
           v-bind:disabled="!isFilterValid"
           @click.prevent="translateToRaw"
-        >
-          <i class="fa fa-angle-double-right"></i> Translate to RAW
-        </button>
+        >Translate to RAW</button>
       </div>
     </div>
   </form>

--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -2,12 +2,21 @@
   <form class="BasicFilter" @submit.prevent="submitSearch">
     <div class="row">
       <div class="col s12">
-
         <div class="BasicFilter-query row">
-          <p><i class="fa fa-search"></i>Query</p>
+          <p>
+            <i class="fa fa-search"></i>Query
+          </p>
 
-          <div v-for="(orBlock, groupIndex) in filters.basic" v-bind:key="`orBlock-${groupIndex}`" class="BasicFilter-orBlock row">
-            <div v-for="(andBlock, filterIndex) in orBlock" v-bind:key="`andBlock-${filterIndex}`" class="BasicFilter-andBlock row dots">
+          <div
+            v-for="(orBlock, groupIndex) in filters.basic"
+            v-bind:key="`orBlock-${groupIndex}`"
+            class="BasicFilter-orBlock row"
+          >
+            <div
+              v-for="(andBlock, filterIndex) in orBlock"
+              v-bind:key="`andBlock-${filterIndex}`"
+              class="BasicFilter-andBlock row dots"
+            >
               <div class="col s4">
                 <autocomplete
                   input-class="validate"
@@ -19,19 +28,26 @@
               </div>
               <div class="col s3">
                 <m-select v-model="andBlock.operator">
-                  <option v-for="(label, identifiers) in availableOperands" :value="identifiers" v-bind:key="label">{{label}}</option>
+                  <option
+                    v-for="(label, identifiers) in availableOperands"
+                    :value="identifiers"
+                    v-bind:key="label"
+                  >{{label}}</option>
                 </m-select>
               </div>
               <div class="col s3">
                 <input placeholder="Value" type="text" class="validate" v-model="andBlock.value">
               </div>
               <div class="col s2">
-                <i class="BasicFilter-removeBtn fa fa-times"
-                   @click="removeAndBasicFilter(groupIndex, filterIndex)"></i>
+                <i
+                  class="BasicFilter-removeBtn fa fa-times"
+                  @click="removeAndBasicFilter(groupIndex, filterIndex)"
+                ></i>
                 <a
                   v-if="filterIndex === orBlock.length - 1"
                   class="BasicFilter-andBtn inline btn btn-small waves-effect waves-light"
-                  @click="addAndBasicFilter(groupIndex)">
+                  @click="addAndBasicFilter(groupIndex)"
+                >
                   <i class="fa fa-plus left"></i>And
                 </a>
               </div>
@@ -47,10 +63,17 @@
         </div>
 
         <div class="BasicFilter-sortBlock row" v-if="sortingEnabled">
-          <p><i class="fa fa-sort-amount-asc"></i>Sorting</p>
-          <div class="row block-content" >
+          <p>
+            <i class="fa fa-sort-amount-asc"></i>Sorting
+          </p>
+          <div class="row block-content">
             <div class="col s4">
-              <input placeholder="Attribute" type="text" class="BasicFilter-sortingAttr validate" v-model="filters.sorting.attribute">
+              <input
+                placeholder="Attribute"
+                type="text"
+                class="BasicFilter-sortingAttr validate"
+                v-model="filters.sorting.attribute"
+              >
             </div>
             <div class="BasicFilter-sortingValue col s2">
               <m-select v-model="filters.sorting.order">
@@ -60,12 +83,30 @@
             </div>
           </div>
         </div>
-
       </div>
     </div>
     <div v-if="actionButtonsVisible" class="row card-action">
-      <button type="submit" class="BasicFilter-submitBtn btn waves-effect waves-light primary" @click.prevent="submitSearch">{{submitButtonLabel}}</button>
-      <button class="BasicFilter-resetBtn btn-flat waves-effect waves-light" @click="resetSearch">Reset</button>
+      <div class="col s7">
+        <button
+          type="submit"
+          class="BasicFilter-submitBtn btn waves-effect waves-light primary"
+          @click.prevent="submitSearch"
+        >{{submitButtonLabel}}</button>
+        <button
+          class="BasicFilter-resetBtn btn-flat waves-effect waves-light"
+          @click="resetSearch"
+        >Reset</button>
+      </div>
+      <div class="col s5">
+        <button
+          type="submit"
+          class="BasicFilter-translateBtn btn waves-effect waves-light success right"
+          v-bind:disabled="!isFilterValid"
+          @click.prevent="translateToRaw"
+        >
+          <i class="fa fa-angle-double-right"></i> Translate to RAW
+        </button>
+      </div>
     </div>
   </form>
 </template>
@@ -73,6 +114,10 @@
 <script>
 import MSelect from '../../Common/MSelect'
 import Autocomplete from '../Autocomplete'
+import {
+  formatFromBasicSearch,
+  formatSort
+} from '../../../services/filterManager'
 
 const emptyBasicFilter = { attribute: null, operator: 'match', value: null }
 const emptySorting = { attribute: null, order: 'asc' }
@@ -228,6 +273,11 @@ export default {
       }
 
       return attributes
+    },
+    translateToRaw() {
+      const rawFilter = formatFromBasicSearch(this.filters.basic)
+      rawFilter.sort = formatSort(this.filters.sorting)
+      this.$emit('translated-to-raw', rawFilter)
     }
   },
   watch: {

--- a/src/components/Common/Filters/Filters.vue
+++ b/src/components/Common/Filters/Filters.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="Filters">
-
     <quick-filter
       :advanced-query-label="advancedQueryLabel"
       :submit-button-label="submitButtonLabel"
@@ -12,15 +11,23 @@
       @display-advanced-filters="advancedFiltersVisible = !advancedFiltersVisible"
       @update-filter="onQuickFilterUpdated"
       @refresh="onRefresh"
-      @reset="onReset">
-    </quick-filter>
-
+      @reset="onReset"
+    ></quick-filter>
 
     <div class="row card-panel Filters-advanced" v-show="advancedFiltersVisible">
       <i class="Filters-btnClose fa fa-times close" @click="advancedFiltersVisible = false"></i>
-      <tabs @tab-changed="switchComplexFilterTab" :active="complexFiltersSelectedTab" :is-displayed="advancedFiltersVisible" :object-tab-active="objectTabActive">
-        <tab @tabs-on-select="setObjectTabActive" name="basic" tab-select="basic"><a href="">Basic Mode</a></tab>
-        <tab @tabs-on-select="setObjectTabActive" name="raw" tab-select="basic"><a href="">Raw JSON Mode</a></tab>
+      <tabs
+        @tab-changed="switchComplexFilterTab"
+        :active="complexFiltersSelectedTab"
+        :is-displayed="advancedFiltersVisible"
+        :object-tab-active="objectTabActive"
+      >
+        <tab @tabs-on-select="setObjectTabActive" name="basic" tab-select="basic">
+          <a href>Basic Mode</a>
+        </tab>
+        <tab @tabs-on-select="setObjectTabActive" name="raw">
+          <a href>Raw JSON Mode</a>
+        </tab>
 
         <div slot="contents" class="card">
           <div class="col s12">
@@ -34,8 +41,9 @@
                 :sorting="sorting"
                 :collection-mapping="collectionMapping"
                 @update-filter="onBasicFilterUpdated"
-                @reset="onReset">
-              </basic-filter>
+                @reset="onReset"
+                @translated-to-raw="onTranslatedToRaw"
+              ></basic-filter>
             </div>
 
             <div v-show="complexFiltersSelectedTab === 'raw'">
@@ -46,8 +54,8 @@
                 :action-buttons-visible="actionButtonsVisible"
                 :submit-button-label="submitButtonLabel"
                 @update-filter="onRawFilterUpdated"
-                @reset="onReset">
-              </raw-filter>
+                @reset="onReset"
+              ></raw-filter>
             </div>
           </div>
         </div>
@@ -243,6 +251,10 @@ export default {
     },
     onFiltersUpdated(newFilters) {
       this.$emit('filters-updated', newFilters)
+    },
+    onTranslatedToRaw(rawFilter) {
+      this.switchComplexFilterTab('raw')
+      this.$emit('set-raw-filter', rawFilter)
     }
   },
   mounted() {

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -425,7 +425,6 @@ export default {
       }
 
       const sorting = filterManager.toSort(this.currentFilter)
-      console.log(sorting)
       // TODO: refactor how search is done
       // Execute search with corresponding searchQuery
       this.performSearchDocuments(

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -3,12 +3,7 @@
   <div class="DocumentsPage">
     <headline>
       {{collection}}
-      <collection-dropdown
-        class="icon-medium icon-black"
-        :index="index"
-        :collection="collection"
-      >
-      </collection-dropdown>
+      <collection-dropdown class="icon-medium icon-black" :index="index" :collection="collection"></collection-dropdown>
     </headline>
 
     <collection-tabs></collection-tabs>
@@ -16,104 +11,97 @@
     <list-not-allowed v-if="!canSearchDocument(index, collection)"></list-not-allowed>
 
     <div class="DocumentsPage-container">
+      <div v-if="isCollectionEmpty" class="card-panel">
+        <realtime-only-empty-state
+          v-if="isRealtimeCollection"
+          :index="index"
+          :collection="collection"
+        ></realtime-only-empty-state>
+        <empty-state v-else :index="index" :collection="collection"></empty-state>
+      </div>
 
-        <div v-if="isCollectionEmpty" class="card-panel">
-          <realtime-only-empty-state
-            v-if="isRealtimeCollection"
-            :index="index"
-            :collection="collection"
-          >
-          </realtime-only-empty-state>
-          <empty-state
-            v-else
-            :index="index"
-            :collection="collection"
-          >
-          </empty-state>
-        </div>
-
-        <div v-if="!isCollectionEmpty">
-
-          <div class="card-panel card-header">
-            <div class="DocumentsPage-filtersAndButtons row">
-              <div class="col s9 xl9">
-                <filters
-                  :available-operands="searchFilterOperands"
-                  :current-filter="currentFilter"
-                  :collection-mapping="collectionMapping"
-                  @filters-updated="onFiltersUpdated"
-                  @reset="onFiltersUpdated"
-                >
-                </filters>
-              </div>
-              <div class="col s3 xl3">
-                <list-view-buttons
-                  :active-view="listViewType"
-                  :boxes-enabled="true"
-                  :map-enabled="isCollectionGeo"
-                  @list="onListViewClicked"
-                  @boxes="onBoxesViewClicked"
-                  @map="onMapViewClicked"
-                >
-                </list-view-buttons>
-              </div>
+      <div v-if="!isCollectionEmpty">
+        <div class="card-panel card-header">
+          <div class="DocumentsPage-filtersAndButtons row">
+            <div class="col s9 xl9">
+              <filters
+                :available-operands="searchFilterOperands"
+                :current-filter="currentFilter"
+                :collection-mapping="collectionMapping"
+                @filters-updated="onFiltersUpdated"
+                @reset="onFiltersUpdated"
+                @set-raw-filter="onSetRawFilter"
+              ></filters>
+            </div>
+            <div class="col s3 xl3">
+              <list-view-buttons
+                :active-view="listViewType"
+                :boxes-enabled="true"
+                :map-enabled="isCollectionGeo"
+                @list="onListViewClicked"
+                @boxes="onBoxesViewClicked"
+                @map="onMapViewClicked"
+              ></list-view-buttons>
             </div>
           </div>
+        </div>
 
-          <div class="card-panel card-body">
-            <no-results-empty-state v-show="!documents.length"></no-results-empty-state>
+        <div class="card-panel card-body">
+          <no-results-empty-state v-show="!documents.length"></no-results-empty-state>
 
-            <list-actions
-              v-if="documents.length"
-              :all-checked="allChecked"
-              :display-bulk-delete="hasSelectedDocuments"
-              :geopointList="mappingGeopoints"
-              :viewType="listViewType"
-              :displayCreate="canCreateDocument(this.index, this.collection)"
-              :displayGeopointSelect="listViewType === 'map'"
-              :displayBulkDelete="listViewType !== 'map'"
-              :displayToggleAll="listViewType !== 'map'"
-              @create="onCreateClicked"
-              @bulk-delete="onBulkDeleteClicked"
-              @toggle-all="onToggleAllClicked"
-              @select-geopoint="onSelectGeopoint"
-            >
-            </list-actions>
+          <list-actions
+            v-if="documents.length"
+            :all-checked="allChecked"
+            :display-bulk-delete="hasSelectedDocuments"
+            :geopointList="mappingGeopoints"
+            :viewType="listViewType"
+            :displayCreate="canCreateDocument(this.index, this.collection)"
+            :displayGeopointSelect="listViewType === 'map'"
+            :displayBulkDelete="listViewType !== 'map'"
+            :displayToggleAll="listViewType !== 'map'"
+            @create="onCreateClicked"
+            @bulk-delete="onBulkDeleteClicked"
+            @toggle-all="onToggleAllClicked"
+            @select-geopoint="onSelectGeopoint"
+          ></list-actions>
 
-            <div class="row" v-show="documents.length">
-
-              <div class="DocumentList-list col s12" v-show="listViewType === 'list'">
-                <div class="DocumentList-materializeCollection collection">
-                  <div class="collection-item collection-transition" v-for="document in documents" :key="document.id">
-                    <document-list-item
-                      :document="document"
-                      :collection="collection"
-                      :index="index"
-                      :is-checked="isChecked(document.id)"
-                      @checkbox-click="toggleSelectDocuments"
-                      @edit="onEditDocumentClicked"
-                      @delete="onDeleteClicked">
-                    </document-list-item>
-                  </div>
+          <div class="row" v-show="documents.length">
+            <div class="DocumentList-list col s12" v-show="listViewType === 'list'">
+              <div class="DocumentList-materializeCollection collection">
+                <div
+                  class="collection-item collection-transition"
+                  v-for="document in documents"
+                  :key="document.id"
+                >
+                  <document-list-item
+                    :document="document"
+                    :collection="collection"
+                    :index="index"
+                    :is-checked="isChecked(document.id)"
+                    @checkbox-click="toggleSelectDocuments"
+                    @edit="onEditDocumentClicked"
+                    @delete="onDeleteClicked"
+                  ></document-list-item>
                 </div>
+              </div>
 
-                <div class="row" v-show="documents.length">
-                  <div class="col s12">
-                    <pagination
+              <div class="row" v-show="documents.length">
+                <div class="col s12">
+                  <pagination
                     :from="paginationFrom"
                     :max-page="1000"
                     :number-in-page="documents.length"
                     :size="paginationSize"
                     :total="totalDocuments"
                     @change-page="changePage"
-                    ></pagination>
-                  </div>
+                  ></pagination>
                 </div>
               </div>
+            </div>
 
-              <div class="col s12" v-show="listViewType === 'boxes'">
-                <div class="DocumentList-boxes">
-                  <document-box-item
+            <div class="col s12" v-show="listViewType === 'boxes'">
+              <div class="DocumentList-boxes">
+                <document-box-item
                   v-for="document in documents"
                   :collection="collection"
                   :index="index"
@@ -121,39 +109,37 @@
                   :key="document.id"
                   @edit="onEditDocumentClicked"
                   @delete="onDeleteClicked"
-                  >
-                </document-box-item>
-                </div>
-
-                <div class="row" v-show="documents.length">
-                  <div class="col s12">
-                    <pagination
-                      :from="paginationFrom"
-                      :max-page="1000"
-                      :number-in-page="documents.length"
-                      :size="paginationSize"
-                      :total="totalDocuments"
-                      @change-page="changePage"
-                    ></pagination>
-                  </div>
-                </div>
+                ></document-box-item>
               </div>
 
-              <div class="DocumentList-map col s12" v-if="listViewType === 'map'">
-                <view-map
-                  :documents="geoDocuments"
-                  :getCoordinates="this.getCoordinates"
-                  :selectedGeopoint="selectedGeopoint"
-                  :index="index"
-                  :collection="collection"
-                  @edit="onEditDocumentClicked"
-                  @delete="onDeleteClicked"
-                />
+              <div class="row" v-show="documents.length">
+                <div class="col s12">
+                  <pagination
+                    :from="paginationFrom"
+                    :max-page="1000"
+                    :number-in-page="documents.length"
+                    :size="paginationSize"
+                    :total="totalDocuments"
+                    @change-page="changePage"
+                  ></pagination>
+                </div>
               </div>
+            </div>
+
+            <div class="DocumentList-map col s12" v-if="listViewType === 'map'">
+              <view-map
+                :documents="geoDocuments"
+                :getCoordinates="this.getCoordinates"
+                :selectedGeopoint="selectedGeopoint"
+                :index="index"
+                :collection="collection"
+                @edit="onEditDocumentClicked"
+                @delete="onDeleteClicked"
+              />
             </div>
           </div>
         </div>
-
+      </div>
     </div>
     <delete-modal
       :candidates-for-deletion="candidatesForDeletion"
@@ -161,8 +147,7 @@
       :is-open="deleteModalIsOpen"
       @close="closeDeleteModal"
       @confirm="onDeleteConfirmed"
-    >
-    </delete-modal>
+    ></delete-modal>
   </div>
 </template>
 
@@ -558,6 +543,9 @@ export default {
         otherQueryParams
       )
       this.$router.push({ query: mergedQuery })
+    },
+    onSetRawFilter(rawFilter) {
+      this.currentFilter.raw = rawFilter
     }
   },
   watch: {

--- a/test/e2e/cypress/integration/collections.spec.js
+++ b/test/e2e/cypress/integration/collections.spec.js
@@ -28,6 +28,7 @@ describe('Collection management', function() {
   it('is able to create a realtime collection and access it', function() {
     cy.visit('/')
     cy.get('.LoginAsAnonymous-Btn').click()
+    cy.contains('Indexes')
     cy.visit(`/#/data/${indexName}/create`)
 
     cy.get('.Mapping-name').click()

--- a/test/e2e/cypress/integration/search.spec.js
+++ b/test/e2e/cypress/integration/search.spec.js
@@ -346,7 +346,7 @@ describe('Search', function() {
     })
   })
 
-  it.only('translates a search query from basic filter to raw filter', function() {
+  it('translates a search query from basic filter to raw filter', function() {
     cy.request('POST', `${kuzzleUrl}/${indexName}/${collectionName}/_create`, {
       firstName: 'Adrien',
       lastName: 'Maret',

--- a/test/e2e/cypress/integration/search.spec.js
+++ b/test/e2e/cypress/integration/search.spec.js
@@ -345,4 +345,44 @@ describe('Search', function() {
       expect($el.last()).to.contain('Marchesini')
     })
   })
+
+  it.only('translates a search query from basic filter to raw filter', function() {
+    cy.request('POST', `${kuzzleUrl}/${indexName}/${collectionName}/_create`, {
+      firstName: 'Adrien',
+      lastName: 'Maret',
+      job: 'Blockchain Keylogger as a Service'
+    })
+    cy.request('POST', `${kuzzleUrl}/${indexName}/${collectionName}/_create`, {
+      firstName: 'Nicolas',
+      lastName: 'Juelle',
+      job: 'CSS Level: Expert !important'
+    })
+    cy.request('POST', `${kuzzleUrl}/${indexName}/${collectionName}/_create`, {
+      firstName: 'Alexandre',
+      lastName: 'Bouthinon',
+      job: 'From scratch All the Things!'
+    })
+
+    cy.visit('/')
+    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.contains('Indexes')
+    cy.visit(`/#/data/${indexName}/${collectionName}`)
+
+    cy.get('.QuickFilter-optionBtn').click()
+    cy.get('.BasicFilter-query input[placeholder=Attribute]').type('job')
+    cy.get('.BasicFilter-query input[placeholder=Value]').type('Blockchain')
+
+    cy.get('.BasicFilter-sortingAttr').type('lastName')
+    cy.get('.BasicFilter-sortingValue')
+      .click()
+      .contains('desc')
+      .click()
+
+    cy.get('.BasicFilter-translateBtn').click()
+    cy.get('.ace_content')
+      .should('contain', 'query')
+      .and('contain', 'must')
+      .and('contain', 'match_phrase_prefix')
+      .and('contain', 'Blockchain')
+  })
 })


### PR DESCRIPTION
## What does this PR do ?
This PR introduces the feature to see a query made via the Basic filter in the Raw filter tab, so that the user can see the actual Elasticsearch specification for the query. This is useful to learn the Elasticsearch DSL but also to have a simple way to generate queries that the user can enrich manually later.

### How should this be manually tested?

1. Log into a Kuzzle with some data
2. Create a Basic filter
3. Click the "Translate to Raw" button
4. You should see the Raw filter editor filled with the query.

### Boyscout

The new version of Prettier installed in my VSCode just formatted the `template` part of the files that I have touched.

