### PR TITLE
Fix 493 list only restricted index

### DIFF
--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -440,7 +440,7 @@ export default {
       }
 
       const sorting = filterManager.toSort(this.currentFilter)
-      console.log(sorting)
+
       // TODO: refactor how search is done
       // Execute search with corresponding searchQuery
       this.performSearchDocuments(

--- a/src/components/Data/Layout.vue
+++ b/src/components/Data/Layout.vue
@@ -72,7 +72,7 @@ export default {
             collection: this.$route.params.collection
           })
         })
-        .catch(err => console.error(err))
+        .catch(() => null)
     }
   },
   watch: {

--- a/src/components/Data/Layout.vue
+++ b/src/components/Data/Layout.vue
@@ -72,7 +72,7 @@ export default {
             collection: this.$route.params.collection
           })
         })
-        .catch(() => null)
+        .catch(error => console.error(error))
     }
   },
   watch: {

--- a/src/components/Data/Leftnav/Treeview.vue
+++ b/src/components/Data/Leftnav/Treeview.vue
@@ -10,7 +10,7 @@
         </ul>
       </li>
     </ul>
-    <ul v-if="canSearchIndex()" class="Treeview-container side-nav fixed leftside-navigation ps-container ps-active-y">
+    <ul v-else class="Treeview-container side-nav fixed leftside-navigation ps-container ps-active-y">
       <li>
         <nav>
           <div class="nav-wrapper">

--- a/src/services/userAuthorization.js
+++ b/src/services/userAuthorization.js
@@ -22,7 +22,10 @@ function isActionAllowed(
 // Index CRUDL
 
 export const canSearchIndex = () => {
-  const indexListRight = store.state.user.rights.filter(rights => rights.action === 'list' && rights.controller === 'index')
+  const indexListRight = store.state.user.rights.filter(rights =>
+    (rights.action === 'list' || rights.action === '*') &&
+    (rights.controller === 'index' || rights.controller === '*')
+  )
 
   return indexListRight[0].value === 'allowed'
 }

--- a/src/services/userAuthorization.js
+++ b/src/services/userAuthorization.js
@@ -27,7 +27,7 @@ export const canSearchIndex = () => {
     (rights.controller === 'index' || rights.controller === '*')
   )
 
-  return indexListRight[0].value === 'allowed'
+  return indexListRight[0] && indexListRight[0].value === 'allowed'
 }
 export const canCreateIndex = () => {
   return isActionAllowed(store.state.user, 'index', 'create')

--- a/src/services/userAuthorization.js
+++ b/src/services/userAuthorization.js
@@ -22,7 +22,9 @@ function isActionAllowed(
 // Index CRUDL
 
 export const canSearchIndex = () => {
-  return isActionAllowed(store.state.user, 'index', 'list')
+  const indexListRight = store.state.user.rights.filter(rights => rights.action === 'list' && rights.controller === 'index')
+
+  return indexListRight[0].value === 'allowed'
 }
 export const canCreateIndex = () => {
   return isActionAllowed(store.state.user, 'index', 'create')

--- a/src/vuex/modules/index/actions.js
+++ b/src/vuex/modules/index/actions.js
@@ -64,7 +64,11 @@ export default {
             .then(res => {
               commit(types.RECEIVE_INDEXES_COLLECTIONS, res || {})
             })
-            .catch(() => null) // Silent on purpose when listCollection is forbidden
+            .catch(error => {
+              if (error.message.indexOf('Forbidden') === -1) {
+                reject(error)
+              }
+            })
 
           promises.push(promise)
           /* eslint-enable */

--- a/src/vuex/modules/index/actions.js
+++ b/src/vuex/modules/index/actions.js
@@ -61,16 +61,16 @@ export default {
               resolveOne(indexesAndCollections)
             })
           })
+            .then(res => {
+              commit(types.RECEIVE_INDEXES_COLLECTIONS, res || {})
+            })
+            .catch(() => null) // Silent on purpose when listCollection is forbidden
+
           promises.push(promise)
           /* eslint-enable */
         })
 
-        Promise.all(promises)
-          .then(res => {
-            commit(types.RECEIVE_INDEXES_COLLECTIONS, res[0] || [])
-            resolve()
-          })
-          .catch(error => reject(error))
+        Promise.all(promises).then(() => resolve())
       })
     })
   },

--- a/test/e2e/cypress/integration/collections.spec.js
+++ b/test/e2e/cypress/integration/collections.spec.js
@@ -28,6 +28,7 @@ describe('Collection management', function() {
   it('is able to create a realtime collection and access it', function() {
     cy.visit('/')
     cy.get('.LoginAsAnonymous-Btn').click()
+    cy.contains('testindex')
     cy.visit(`/#/data/${indexName}/create`)
 
     cy.get('.Mapping-name')


### PR DESCRIPTION
## What does this PR do ?

Allows to list indexes even if the current user is restricted to some.

Fix: https://github.com/kuzzleio/kuzzle-admin-console/issues/493

### How should this be manually tested?

  - Step 1 : Create an user with a profile restricted to an index
  - Step 2 : You should see only the restricted index
