### PR TITLE
Fix dead links to Kuzzle's documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-admin-console",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-admin-console",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "A handy administrative console for Kuzzle",
   "author": "The Kuzzle team <support@kuzzle.io>",
   "private": false,

--- a/src/components/Common/CrudlDocument.vue
+++ b/src/components/Common/CrudlDocument.vue
@@ -21,7 +21,7 @@
             Please try with another filter.
           </p>
           <p>
-            <em>Learn more about filtering syntax on <a href="http://docs.kuzzle.io/elasticsearch-cookbook/" target="_blank">Kuzzle Elasticsearch Cookbook</a></em>
+            <em>Learn more about filtering syntax on <a href="https://docs.kuzzle.io/guide/1/elasticsearch/" target="_blank">Kuzzle Elasticsearch Cookbook</a></em>
           </p>
         </div>
       </div>

--- a/src/components/Common/ListNotAllowed.vue
+++ b/src/components/Common/ListNotAllowed.vue
@@ -9,7 +9,7 @@
           You are not allowed to access this list<br>
         </p>
         <p>
-          <em>Learn more about security &amp; permissions on <a href="http://docs.kuzzle.io/guide/essentials/security/" target="_blank">Kuzzle guide</a></em>
+          <em>Learn more about security &amp; permissions on <a href="https://docs.kuzzle.io/guide/1/essentials/security/" target="_blank">Kuzzle guide</a></em>
         </p>
       </div>
     </div>

--- a/src/components/Common/PageNotAllowed.vue
+++ b/src/components/Common/PageNotAllowed.vue
@@ -11,7 +11,7 @@
             You are not allowed to access this page<br>
           </p>
           <p>
-            <em>Learn more about security &amp; permissions on <a href="http://docs.kuzzle.io/guide/essentials/security/#permissions" target="_blank">Kuzzle guide</a></em>
+            <em>Learn more about security &amp; permissions on <a href="https://docs.kuzzle.io/guide/1/essentials/security/#user-permissions" target="_blank">Kuzzle guide</a></em>
           </p>
         </div>
       </div>

--- a/src/components/Data/Collections/Steps/Mapping.vue
+++ b/src/components/Data/Collections/Steps/Mapping.vue
@@ -56,7 +56,7 @@
           <p class="help">
             Mapping is the process of defining how a document,
             and the fields it contains, are stored and indexed.
-            <a href="http://docs.kuzzle.io/api-documentation/controller-collection/update-mapping/" target="_blank">Read more about mapping</a>
+            <a href="https://docs.kuzzle.io/api/1/controller-collection/update-mapping/" target="_blank">Read more about mapping</a>
             <br>
             You should omit the root "properties" field in this form.
             <pre>

--- a/src/components/Data/Collections/Watch.vue
+++ b/src/components/Data/Collections/Watch.vue
@@ -22,7 +22,7 @@
               You are not allowed to watch realtime messages on collection <strong>{{collection}}</strong> of index <strong>{{index}}</strong><br>
             </p>
             <p>
-              <em>Learn more about security &amp; permissions on <a href="http://docs.kuzzle.io/guide/essentials/security/" target="_blank">Kuzzle guide</a></em>
+              <em>Learn more about security &amp; permissions on <a href="https://docs.kuzzle.io/guide/1/essentials/security/" target="_blank">Kuzzle guide</a></em>
             </p>
           </div>
         </div>
@@ -65,7 +65,7 @@
             <div class="col s8 m9 l10">
               <p>
                 You did not subscribe yet to the collection <strong>{{collection}}</strong><br>
-                <em>Learn more about real-time filtering syntax on <a href="http://docs.kuzzle.io/kuzzle-dsl/" target="_blank">Kuzzle DSL</a></em>
+                <em>Learn more about real-time filtering syntax on <a href="https://docs.kuzzle.io/koncorde/" target="_blank">Kuzzle DSL</a></em>
               </p>
               <button class="btn primary waves-effect waves-light" @click="toggleSubscription()">
                 <i class="fa left fa-play"></i>
@@ -85,7 +85,7 @@
                 Waiting for notifications matching your filters ...
               </p>
               <p>
-                <em>Learn more about real-time filtering syntax on <a href="http://docs.kuzzle.io/kuzzle-dsl/" target="_blank">Kuzzle DSL</a></em>
+                <em>Learn more about real-time filtering syntax on <a href="https://docs.kuzzle.io/koncorde/" target="_blank">Kuzzle DSL</a></em>
               </p>
             </div>
           </div>

--- a/src/components/Data/Documents/NoResultsEmptyState.vue
+++ b/src/components/Data/Documents/NoResultsEmptyState.vue
@@ -9,7 +9,7 @@
             Please try with another filter.
           </p>
           <p>
-            <em>Learn more about filtering syntax on <a href="http://docs.kuzzle.io/elasticsearch-cookbook/" target="_blank">Kuzzle Elasticsearch Cookbook</a></em>
+            <em>Learn more about filtering syntax on <a href="https://docs.kuzzle.io/guide/1/elasticsearch/" target="_blank">Kuzzle Elasticsearch Cookbook</a></em>
           </p>
         </div>
       </div>

--- a/src/components/Security/Profiles/CrudlDocument.vue
+++ b/src/components/Security/Profiles/CrudlDocument.vue
@@ -17,7 +17,7 @@
             Please try with another filters.
           </p>
           <p>
-            <em>Learn more about filtering syntax on <a href="http://docs.kuzzle.io/elasticsearch-cookbook/" target="_blank">Kuzzle Elasticsearch Cookbook</a></em>
+            <em>Learn more about filtering syntax on <a href="https://docs.kuzzle.io/guide/1/elasticsearch/" target="_blank">Kuzzle Elasticsearch Cookbook</a></em>
           </p>
         </div>
       </div>

--- a/src/components/Security/Profiles/Page.vue
+++ b/src/components/Security/Profiles/Page.vue
@@ -22,7 +22,7 @@
           </div>
           <div class="col s10">
             <p>
-              In this page, you'll be able to manage the <a href="https://docs.kuzzle.io/guide/essentials/security">Security Profiles</a>
+              In this page, you'll be able to manage the <a href="https://docs.kuzzle.io/guide/1/essentials/security/#defining-profiles">Security Profiles</a>
               defined in your Kuzzle server.<br/>
               <em>Currently, no Profile is defined. You can create one by pushing the "Create" button above.</em>
             </p>

--- a/src/components/Security/Roles/Page.vue
+++ b/src/components/Security/Roles/Page.vue
@@ -21,7 +21,7 @@
           </div>
           <div class="col s10">
             <p>
-              In this page, you'll be able to manage the <a href="https://docs.kuzzle.io/guide/essentials/security">Security Roles</a>
+              In this page, you'll be able to manage the <a href="https://docs.kuzzle.io/guide/1/essentials/security/#defining-roles">Security Roles</a>
               defined in your Kuzzle server.<br/>
               <em>Currently, no Security Role is defined. You can create one by pushing the "Create" button above.</em>
             </p>

--- a/src/components/Security/Users/Page.vue
+++ b/src/components/Security/Users/Page.vue
@@ -29,7 +29,7 @@
           </div>
           <div class="col s10">
             <p>
-              In this page, you'll be able to manage the <a href="https://docs.kuzzle.io/guide/essentials/user-authentication">users</a>
+              In this page, you'll be able to manage the <a href="https://docs.kuzzle.io/guide/1/essentials/user-authentication/">users</a>
               defined in your Kuzzle server.<br/>
               <em>Currently, no user is defined. You can create one by pushing the "Create" button above.</em>
             </p>

--- a/src/components/Security/Users/Steps/Mapping.vue
+++ b/src/components/Security/Users/Steps/Mapping.vue
@@ -19,7 +19,7 @@
           <p class="help">
             Mapping is the process of defining how a document,
             and the fields it contains, are stored and indexed.
-            <a href="http://docs.kuzzle.io/v/edge/api-documentation/controller-collection/update-mapping/" target="_blank">Read more about mapping</a>
+            <a href="https://docs.kuzzle.io/api/1/controller-collection/update-mapping/" target="_blank">Read more about mapping</a>
           </br>
             You should omit the root "properties" field in this form.
             <pre>


### PR DESCRIPTION
:rotating_light: HOTFIX :rotating_light: 

# Description

Migrate the documentation links, from the old documentation website to the new one.

# Hotfix reason

All documentation links displayed by the admin console are currently dead.
