### PR TITLE
[bugfix] allow anonymous to log out

### DIFF
--- a/src/vuex/modules/auth/actions.js
+++ b/src/vuex/modules/auth/actions.js
@@ -77,9 +77,11 @@ export default {
     }
   },
   async [types.DO_LOGOUT]({ commit, dispatch }) {
-    await Vue.prototype.$kuzzle
-      .auth
-      .logout()
+    if (Vue.prototype.$kuzzle.jwt) {
+      await Vue.prototype.$kuzzle
+        .auth
+        .logout()
+    }
     Vue.prototype.$kuzzle.jwt = null
     dispatch(kuzzleTypes.UPDATE_TOKEN_CURRENT_ENVIRONMENT, null)
     commit(types.SET_CURRENT_USER, SessionUser())


### PR DESCRIPTION
## What does this PR do ?

Since Kuzzle now rejects the logout call for an anonymous user, the log out was broken in this case in the admin console and the anonymous user could not switch to another user.
This PR fixes this situation.