### PR TITLE
[HOTFIX] Fix a bug where it is not possible to create a collection with kuzzle >= 1.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-admin-console",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-admin-console",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A handy administrative console for Kuzzle",
   "author": "The Kuzzle team <support@kuzzle.io>",
   "private": false,

--- a/src/vuex/modules/collection/actions.js
+++ b/src/vuex/modules/collection/actions.js
@@ -8,7 +8,7 @@ export default {
     return kuzzle.queryPromise(
       {
         controller: 'collection',
-        action: 'updateMapping'
+        action: 'create'
       },
       {
         collection: state.name,


### PR DESCRIPTION
## What does this PR do ?

Since Kuzzle 1.7.3 `updateMapping` won't create the collection if it does not exist.
The admin console used this route to create a new collection (I don't know why) so now it uses `createCollection`

:warning: Once merged to `master` merge back to `1-dev`