### PR TITLE
Fix impossibility to edit documents with spaces in id (issue #547)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10821,9 +10821,9 @@
       }
     },
     "node-sass": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-      "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
+      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "materialize-css": "^1.0.0",
     "mocha": "^5.2.0",
     "moment": "^2.22.1",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.12.0",
     "opn": "^4.0.2",
     "optimize-css-assets-webpack-plugin": "^1.3.0",
     "ora": "^1.4.0",

--- a/src/components/Common/CommonList.vue
+++ b/src/components/Common/CommonList.vue
@@ -235,7 +235,7 @@ export default {
     editDocument(route, id) {
       this.$router.push({
         name: this.routeUpdate,
-        params: { id: encodeURIComponent(id) }
+        params: { id }
       })
     },
     deleteDocument(id) {

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -509,7 +509,7 @@ export default {
     onEditDocumentClicked(id) {
       this.$router.push({
         name: 'DataUpdateDocument',
-        params: { id: encodeURIComponent(id) }
+        params: { id }
       })
     },
 

--- a/src/components/Data/Documents/Update.vue
+++ b/src/components/Data/Documents/Update.vue
@@ -4,7 +4,7 @@
     class="wrapper"
   >
     <headline>
-      Edit document - <span class="bold">{{ decodeURIComponent($route.params.id) }}</span>
+      Edit document - <span class="bold">{{ $route.params.id }}</span>
       <collection-dropdown
         class="icon-medium icon-black"
         :index="index"
@@ -96,7 +96,7 @@ export default {
   async mounted() {
     this.fetch()
     this.room = await this.$kuzzle.realtime.subscribe(this.index, this.collection,
-      { ids: { values: [decodeURIComponent(this.$route.params.id)] } },
+      { ids: { values: [this.$route.params.id] } },
       () => {
         this.show = true
       })

--- a/src/components/Security/Common/List.vue
+++ b/src/components/Security/Common/List.vue
@@ -189,7 +189,7 @@ export default {
     editDocument(route, id) {
       this.$router.push({
         name: this.routeUpdate,
-        params: { id: encodeURIComponent(id) }
+        params: { id }
       })
     },
     deleteDocument(id) {

--- a/src/components/Security/Profiles/CommonList.vue
+++ b/src/components/Security/Profiles/CommonList.vue
@@ -182,7 +182,7 @@ export default {
     editDocument(route, id) {
       this.$router.push({
         name: this.routeUpdate,
-        params: { id: encodeURIComponent(id) }
+        params: { id }
       })
     },
     deleteDocument(id) {

--- a/src/components/Security/Profiles/Update.vue
+++ b/src/components/Security/Profiles/Update.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Headline>
-      Edit profile - <span class="bold">{{ decodeURIComponent($route.params.id) }}</span>
+      Edit profile - <span class="bold">{{ $route.params.id }}</span>
     </Headline>
     <Notice />
     <create-or-update

--- a/src/components/Security/Roles/List.vue
+++ b/src/components/Security/Roles/List.vue
@@ -174,7 +174,7 @@ export default {
     editDocument(route, id) {
       this.$router.push({
         name: this.routeUpdate,
-        params: { id: encodeURIComponent(id) }
+        params: { id }
       })
     },
     deleteDocument(id) {

--- a/src/components/Security/Roles/Update.vue
+++ b/src/components/Security/Roles/Update.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Headline>
-      Edit role - <span class="bold">{{ decodeURIComponent($route.params.id) }}</span>
+      Edit role - <span class="bold">{{ $route.params.id }}</span>
     </Headline>
     <Notice />
     <create-or-update

--- a/src/components/Security/Users/Steps/StepsContent.vue
+++ b/src/components/Security/Users/Steps/StepsContent.vue
@@ -78,7 +78,7 @@ export default {
       }
 
       if (this.isUpdate) {
-        this.kuid = decodeURIComponent(this.$route.params.id)
+        this.kuid = this.$route.params.id
 
         await Promise.all(
           this.strategies.map(async strategy => {

--- a/src/components/Security/Users/Update.vue
+++ b/src/components/Security/Users/Update.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="wrapper">
     <headline>
-      Edit user - <span class="bold">{{ decodeURIComponent($route.params.id) }}</span>
+      Edit user - <span class="bold">{{ $route.params.id }}</span>
     </headline>
 
     <Notice />


### PR DESCRIPTION
## What does this PR do ?
Solves https://github.com/kuzzleio/kuzzle-admin-console/issues/547

Removed encodeURIComponent of params from push of new url to router, as it is already done by the router
 
### How should this be manually tested?

  - Step 1 : create a document with a space in its id
  - Step 2 : click on the edit button
  - Step 3 :  check that the document is indeed opened


### Boyscout
In fact all encodeURIComponent in router push params should be removed (there are a few more than this one). But I don't know how to test there are no side effects...
