### PR TITLE
Sort documents on _id field

### DIFF
--- a/src/components/Common/CommonList.vue
+++ b/src/components/Common/CommonList.vue
@@ -207,7 +207,7 @@ export default {
         searchQuery = {}
       }
 
-      let sorting = ['_uid'] // by default, sort on uid: prevent random order
+      let sorting = ['_id'] // by default, sort on uid: prevent random order
       if (this.currentFilter.sorting) {
         sorting = filterManager.toSort(this.currentFilter)
       }

--- a/src/components/Common/Environments/EnvironmentsSwitch.vue
+++ b/src/components/Common/Environments/EnvironmentsSwitch.vue
@@ -6,7 +6,7 @@
     <a
       class="btn-flat dropdown-button current-environment grey-text text-lighten-5 waves-effect waves-light"
       :style="{ backgroundColor: bgColor }"
-      :data-target="&quot;environment-dropdown-&quot; + _uid"
+      :data-target="&quot;environment-dropdown-&quot; + _id"
     >
       <span
         v-if="$store.getters.currentEnvironment"
@@ -24,7 +24,7 @@
     </a>
 
     <ul
-      :id="&quot;environment-dropdown-&quot; + _uid"
+      :id="&quot;environment-dropdown-&quot; + _id"
       class="EnvironmentsSwitch-envList dropdown-content environment-dropdown"
     >
       <li

--- a/src/components/Materialize/Dropdown.vue
+++ b/src/components/Materialize/Dropdown.vue
@@ -59,7 +59,7 @@ export default {
         return null
       }
 
-      let parsed = this.id + this._uid
+      let parsed = this.id + this._id
 
       return formatForDom(parsed)
     }

--- a/src/services/filterManager.js
+++ b/src/services/filterManager.js
@@ -262,24 +262,24 @@ export const rawFilterToSearchQuery = rawFilter => {
 export const toSort = filter => {
   switch (filter.active) {
     case ACTIVE_QUICK:
-      return ['_uid']
+      return ['_id']
     case ACTIVE_BASIC:
-      return filter.sorting ? formatSort(filter.sorting) : ['_uid']
+      return filter.sorting ? formatSort(filter.sorting) : ['_id']
     case ACTIVE_RAW:
-      return filter.raw ? rawFilterToSort(filter.raw) : ['_uid']
+      return filter.raw ? rawFilterToSort(filter.raw) : ['_id']
     case NO_ACTIVE:
     default:
-      return ['_uid']
+      return ['_id']
   }
 }
 
 export const rawFilterToSort = rawFilter => {
-  return rawFilter.sort || ['_uid']
+  return rawFilter.sort || ['_id']
 }
 
 export const formatSort = sorting => {
   if (!sorting.attribute) {
-    return ['_uid']
+    return ['_id']
   }
   return [{ [sorting.attribute]: { order: sorting.order } }]
 }

--- a/src/services/kuzzleWrapper.js
+++ b/src/services/kuzzleWrapper.js
@@ -37,7 +37,7 @@ export const connectToEnvironment = environment => {
     port: parseInt(environment.port),
     sslConnection: environment.ssl
   })
-  
+
   Vue.prototype.$kuzzle.connect()
 }
 
@@ -129,7 +129,7 @@ export const performSearchDocuments = async (
   let additionalAttributeName = null
 
   if (sort.length > 0) {
-    if (typeof sort[0] === 'string' && sort[0] !== '_uid') {
+    if (typeof sort[0] === 'string' && sort[0] !== '_id') {
       additionalAttributeName = sort[0]
     } else {
       additionalAttributeName = Object.keys(sort[0])[0]

--- a/test/unit/specs/services/filterManager.spec.js
+++ b/test/unit/specs/services/filterManager.spec.js
@@ -382,8 +382,8 @@ describe('filterManager tests', () => {
   })
 
   describe('toSort tests', () => {
-    it('should sort by `_uid` if no attribute is in sorting', () => {
-      expect(filterManager.toSort({})).to.deep.equals(['_uid'])
+    it('should sort by `_id` if no attribute is in sorting', () => {
+      expect(filterManager.toSort({})).to.deep.equals(['_id'])
     })
 
     it('should return a formatted object when provided a basic filter', () => {


### PR DESCRIPTION
## What does this PR do ?

Sort documents on the `_id` field instead of `_uid` because it was removed in elasticsearch 7: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-uid-field.html
