### PR TITLE
Fix select list in roles and profiles

### DIFF
--- a/src/components/Security/Profiles/CommonList.vue
+++ b/src/components/Security/Profiles/CommonList.vue
@@ -127,13 +127,11 @@ export default {
   },
   methods: {
     async deleteProfiles(index, collection, ids) {
-      try {
-        await this.performDelete(index, collection, ids)
-        this.$set(this.selectedDocuments, this.selectedDocuments.splice(0, this.selectedDocuments.length))
-        this.fetchProfiles()
-      } catch (e) {
-        return Promise.reject(e)
-      }
+      await this.performDelete(index, collection, ids)
+      this.$set(
+        this.selectedDocuments,
+        this.selectedDocuments.splice(0, this.selectedDocuments.length))
+      this.fetchProfiles()
     },
     isChecked(id) {
       return this.selectedDocuments.indexOf(id) > -1

--- a/src/components/Security/Profiles/CommonList.vue
+++ b/src/components/Security/Profiles/CommonList.vue
@@ -19,7 +19,7 @@
       :selected-documents="selectedDocuments"
       :length-document="selectedDocuments.length"
       :document-to-delete="documentToDelete"
-      :perform-delete="performDelete"
+      :perform-delete="deleteProfiles"
       @filters-updated="onFiltersUpdated"
       @create-clicked="create"
       @toggle-all="toggleAll"
@@ -126,6 +126,15 @@ export default {
     )
   },
   methods: {
+    async deleteProfiles(index, collection, ids) {
+      try {
+        await this.performDelete(index, collection, ids)
+        this.$set(this.selectedDocuments, this.selectedDocuments.splice(0, this.selectedDocuments.length))
+        this.fetchProfiles()
+      } catch (e) {
+        return Promise.reject(e)
+      }
+    },
     isChecked(id) {
       return this.selectedDocuments.indexOf(id) > -1
     },

--- a/src/components/Security/Profiles/Create.vue
+++ b/src/components/Security/Profiles/Create.vue
@@ -65,7 +65,7 @@ export default {
           })
         setTimeout(() => {
           // we can't perform refresh index on %kuzzle
-          this.$router.push({ name: 'SecurityRolesList' })
+          this.$router.push({ name: 'SecurityProfilesList' })
         }, 1000)
       } catch (e) {
         this.error =

--- a/src/components/Security/Profiles/Create.vue
+++ b/src/components/Security/Profiles/Create.vue
@@ -63,6 +63,10 @@ export default {
           .createProfile(this.id, { policies: profile.policies }, {
             refresh: 'wait_for'
           })
+        setTimeout(() => {
+          // we can't perform refresh index on %kuzzle
+          this.$router.push({ name: 'SecurityRolesList' })
+        }, 1000)
       } catch (e) {
         this.error =
           'An error occurred while creating profile: <br />' + e.message

--- a/src/components/Security/Roles/List.vue
+++ b/src/components/Security/Roles/List.vue
@@ -120,13 +120,11 @@ export default {
   },
   methods: {
     async deleteRoles(index, collection, ids) {
-      try {
-        await this.performDelete(index, collection, ids)
-        this.$set(this.selectedDocuments, this.selectedDocuments.splice(0, this.selectedDocuments.length))
-        this.fetchRoles()
-      } catch (e) {
-        return Promise.reject(e)
-      }
+      await this.performDelete(index, collection, ids)
+      this.$set(
+        this.selectedDocuments,
+        this.selectedDocuments.splice(0, this.selectedDocuments.length))
+      this.fetchRoles()
     },
     isChecked(id) {
       return this.selectedDocuments.indexOf(id) > -1

--- a/src/components/Security/Roles/List.vue
+++ b/src/components/Security/Roles/List.vue
@@ -17,7 +17,7 @@
       :selected-documents="selectedDocuments"
       :length-document="selectedDocuments.length"
       :document-to-delete="documentToDelete"
-      :perform-delete="performDelete"
+      :perform-delete="deleteRoles"
       @filters-updated="onFiltersUpdated"
       @create-clicked="create"
       @toggle-all="toggleAll"
@@ -119,6 +119,15 @@ export default {
     )
   },
   methods: {
+    async deleteRoles(index, collection, ids) {
+      try {
+        await this.performDelete(index, collection, ids)
+        this.$set(this.selectedDocuments, this.selectedDocuments.splice(0, this.selectedDocuments.length))
+        this.fetchRoles()
+      } catch (e) {
+        return Promise.reject(e)
+      }
+    },
     isChecked(id) {
       return this.selectedDocuments.indexOf(id) > -1
     },


### PR DESCRIPTION
## What does this PR do ?

Fix a bug where when we select a role or profile with the checkbox and delete it, this one would still be in memory of the internal selected documents so when selecting one other document after delete it would think it has 2 documents selected.

Also refresh the content after creating a new profile.