### PR TITLE
[KZL-1447] App layout improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9517,7 +9517,8 @@
     "cypress-plugin-retries": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/cypress-plugin-retries/-/cypress-plugin-retries-1.4.0.tgz",
-      "integrity": "sha512-Pudna9+dn0wp3flUVWt1ttn6hKTnD1MIBUSznYkw+uRv3JPNJhxHIv9cfxrZmig49/R1fIyGBVNORchtnFedEw=="
+      "integrity": "sha512-Pudna9+dn0wp3flUVWt1ttn6hKTnD1MIBUSznYkw+uRv3JPNJhxHIv9cfxrZmig49/R1fIyGBVNORchtnFedEw==",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "chromium": "^1.0.2",
     "commander": "^2.15.1",
     "core-js": "^3.4.3",
-    "cypress-plugin-retries": "^1.4.0",
     "finalhandler": "^1.1.1",
     "http-server": "^0.11.1",
     "serve-static": "^1.13.2",
@@ -111,9 +110,6 @@
     "vuex": "^3.1.2",
     "webpack": "^4.41.2",
     "webpack-dev-server": "^3.9.0"
-  },
-  "peerDependencies": {
-    "cypress": "^3.1.0"
   },
   "bin": "./bin/kuzzle-admin-console",
   "engines": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@
           v-if="!$store.direct.getters.kuzzle.currentEnvironmentId"
           class="App-disconnected"
         ></div>
-        <div v-else data-cy="App-connected" class="h-100">
+        <template v-else data-cy="App-connected" class="h-100">
           <div
             v-if="!$store.direct.getters.auth.isAuthenticated"
             class="App-loggedOut"
@@ -43,13 +43,13 @@
               />
             </div>
           </div>
-          <div v-else class="App-loggedIn h-100" data-cy="App-loggedIn">
+          <template v-else class="App-loggedIn h-100" data-cy="App-loggedIn">
             <router-view
               @environment::create="editEnvironment"
               @environment::delete="deleteEnvironment"
             />
-          </div>
-        </div>
+          </template>
+        </template>
       </template>
     </template>
 
@@ -61,7 +61,7 @@
     <modal-delete id="modal-env-delete" :environment-id="environmentId" />
     <modal-import id="modal-env-import" />
 
-    <toaster />
+    <!-- <toaster /> -->
   </div>
 </template>
 
@@ -78,7 +78,7 @@ import CreateEnvironmentPage from './components/Common/Environments/CreateEnviro
 import ModalCreateOrUpdate from './components/Common/Environments/ModalCreateOrUpdate'
 import ModalDelete from './components/Common/Environments/ModalDelete'
 import ModalImport from './components/Common/Environments/ModalImport'
-import Toaster from './components/Materialize/Toaster.vue'
+// import Toaster from './components/Materialize/Toaster.vue'
 
 // @TODO we'll have to import FA from global.scss one day...
 import '@fortawesome/fontawesome-free/css/all.css'
@@ -90,7 +90,7 @@ export default {
     ModalCreateOrUpdate,
     ModalDelete,
     ModalImport,
-    Toaster,
+    // Toaster,
     KuzzleErrorPage,
     SignUp,
     Login,
@@ -151,8 +151,6 @@ export default {
 
 <style lang="scss" scoped>
 .App {
-  height: 100vh;
-  overflow-x: hidden;
-  background-color: $page-background-color;
+  height: 100%;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,16 +18,16 @@
       <template v-else>
         <div
           v-if="!$store.direct.getters.kuzzle.currentEnvironmentId"
-          class="App-disconnected"
+          data-cy="App-disconnected"
         ></div>
-        <template v-else data-cy="App-connected" class="h-100">
+        <template v-else>
           <div
+            data-cy="App-connected"
             v-if="!$store.direct.getters.auth.isAuthenticated"
-            class="App-loggedOut"
           >
             <div
               v-if="!$store.direct.getters.auth.adminAlreadyExists"
-              class="App-noAdmin"
+              data-cy="App-noAdmin"
             >
               <sign-up
                 @environment::create="editEnvironment"
@@ -35,16 +35,18 @@
                 @environment::importEnv="importEnvironment"
               />
             </div>
-            <div v-else class="App-hasAdmin" data-cy="App-hasAdmin">
+            <div v-else>
               <login
+                data-cy="App-hasAdmin"
                 @environment::create="editEnvironment"
                 @environment::delete="deleteEnvironment"
                 @environment::importEnv="importEnvironment"
               />
             </div>
           </div>
-          <template v-else class="App-loggedIn h-100" data-cy="App-loggedIn">
+          <template v-else>
             <router-view
+              data-cy="App-loggedIn"
               @environment::create="editEnvironment"
               @environment::delete="deleteEnvironment"
             />

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,8 +62,6 @@
     />
     <modal-delete id="modal-env-delete" :environment-id="environmentId" />
     <modal-import id="modal-env-import" />
-
-    <!-- <toaster /> -->
   </div>
 </template>
 
@@ -80,7 +78,6 @@ import CreateEnvironmentPage from './components/Common/Environments/CreateEnviro
 import ModalCreateOrUpdate from './components/Common/Environments/ModalCreateOrUpdate'
 import ModalDelete from './components/Common/Environments/ModalDelete'
 import ModalImport from './components/Common/Environments/ModalImport'
-// import Toaster from './components/Materialize/Toaster.vue'
 
 // @TODO we'll have to import FA from global.scss one day...
 import '@fortawesome/fontawesome-free/css/all.css'
@@ -92,7 +89,6 @@ export default {
     ModalCreateOrUpdate,
     ModalDelete,
     ModalImport,
-    // Toaster,
     KuzzleErrorPage,
     SignUp,
     Login,

--- a/src/assets/layout.scss
+++ b/src/assets/layout.scss
@@ -1,6 +1,26 @@
+/*!
+ * layout.scss
+ */
 html {
-  font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-  font-weight: normal;
-  background-color: #f5f5f5;
-  color: #333;
+  /* We can avoid setting height:100vh on the grid container if we use height:100% 
+     on the root element and then all descendants up until the grid container. 
+     Using 100vh can be a simpler option, but the vh unit can be problematic on 
+     iOS and Android: https://nicolas-hoizey.com/articles/2015/02/18/viewport-height-is-taller-than-the-visible-part-of-the-document-in-some-mobile-browsers/ 
+   */
+  height: 100%;
+  /* With our styles we should not have any cause for a scrollbar on the page itself,
+     so this is not strictly necessary, but to be safe we can prevent scrollbars on
+     the full page. 
+   */
+  overflow: hidden;
+
+  /* Legacy garbage */
+  // font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
+  // font-weight: normal;
+  // background-color: #f5f5f5;
+  // color: #333;
+}
+
+body {
+  height: 100%;
 }

--- a/src/assets/layout.scss
+++ b/src/assets/layout.scss
@@ -13,12 +13,6 @@ html {
      the full page. 
    */
   overflow: hidden;
-
-  /* Legacy garbage */
-  // font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-  // font-weight: normal;
-  // background-color: #f5f5f5;
-  // color: #333;
 }
 
 body {

--- a/src/assets/variables.scss
+++ b/src/assets/variables.scss
@@ -12,7 +12,7 @@ $lavandia-color: #73626e;
 $grey-color: #7b7b7b;
 $disabled-color: #9f9f9f;
 $error-color: red;
-$page-background-color: #f5f5f5;
+$light-grey-color: #f5f5f5;
 
 $link-color: $primary-color;
 $tabs-text-color: $primary-color;

--- a/src/components/Common/Environments/EnvironmentsSwitch.vue
+++ b/src/components/Common/Environments/EnvironmentsSwitch.vue
@@ -1,31 +1,34 @@
 <template>
   <b-dropdown
     ref="dropdown"
-    class="EnvironmentsSwitch"
+    class="EnvironmentSwitch"
+    data-cy="EnvironmentSwitch"
     variant="outline-secondary"
     :text="currentEnvironmentName"
     :block="block"
     :right="right"
-    :class="blendColor ? 'EnvironmentsSwitch--blendColor' : ''"
+    :class="blendColor ? 'EnvironmentSwitch--blendColor' : ''"
   >
     <b-dropdown-item
       v-for="(env, index) in $store.direct.getters.kuzzle.environments"
-      class="EnvironmentsSwitch-env environment"
+      class="EnvironmentSwitch-env environment"
       :key="env.name"
-      :data-env="`env_${formatForDom(env.name)}`"
+      :data-cy="`EnvironmentSwitch-env_${formatForDom(env.name)}`"
     >
       <div @click="clickSwitch(index)">
-        <div class="EnvironmentsSwitch-env-name">
+        <div class="EnvironmentSwitch-env-name">
           {{ env.name }}
           <span class="text-muted ml-2 mr-5">{{ env.host }}</span>
         </div>
-        <div class="EnvironmentsSwitch-env-inputs">
+        <div class="EnvironmentSwitch-env-inputs">
           <i
             class="edit primary fa fa-pencil-alt mr-3"
+            :data-cy="`EnvironmentSwitch-env_${formatForDom(env.name)}-edit`"
             @click.prevent="$emit('environment::create', index)"
           />
           <i
             class="delete error fa fa-trash"
+            :data-cy="`EnvironmentSwitch-env_${formatForDom(env.name)}-delete`"
             @click.prevent="$emit('environment::delete', index)"
           />
         </div>
@@ -33,7 +36,11 @@
     </b-dropdown-item>
     <b-dropdown-divider></b-dropdown-divider>
     <b-dropdown-item>
-      <a href="" @click.prevent="$emit('environment::create')">
+      <a
+        data-cy="EnvironmentSwitch-newConnectionBtn"
+        href=""
+        @click.prevent="$emit('environment::create')"
+      >
         Create new connection
       </a>
     </b-dropdown-item>
@@ -56,7 +63,7 @@ import Promise from 'bluebird'
 import { formatForDom } from '../../../utils'
 
 export default {
-  name: 'EnvironmentsSwitch',
+  name: 'EnvironmentSwitch',
   props: {
     blendColor: {
       type: Boolean,
@@ -115,7 +122,7 @@ export default {
 </script>
 
 <style lang="scss" rel="stylesheet/scss">
-.EnvironmentsSwitch--blendColor {
+.EnvironmentSwitch--blendColor {
   .dropdown-toggle {
     background-color: rgba(255, 255, 255, 0.4);
     border: none;
@@ -129,7 +136,7 @@ export default {
   }
 }
 
-.EnvironmentsSwitch-env {
+.EnvironmentSwitch-env {
   display: table;
 
   &-name {

--- a/src/components/Common/MainMenu.vue
+++ b/src/components/Common/MainMenu.vue
@@ -1,63 +1,60 @@
 <template>
-  <div>
-    <b-navbar
-      fixed="top"
-      toggleable="lg"
-      type="dark"
-      :class="`EnvColor--${currentEnvironmentColor}`"
-    >
-      <b-navbar-brand href="#" class="logo">
-        <img
-          alt="Kuzzle.io"
-          src="~../../assets/logo-white.svg"
-          v-b-tooltip.hover
-          :title="`Admin Console v${adminConsoleVersion}`"
+  <b-navbar
+    toggleable="lg"
+    type="dark"
+    :class="`MainMenu EnvColor--${currentEnvironmentColor}`"
+  >
+    <b-navbar-brand href="#" class="logo">
+      <img
+        alt="Kuzzle.io"
+        src="~../../assets/logo-white.svg"
+        v-b-tooltip.hover
+        :title="`Admin Console v${adminConsoleVersion}`"
+      />
+    </b-navbar-brand>
+    <b-navbar-toggle target="nav-collapse" type="light"></b-navbar-toggle>
+    <b-collapse id="nav-collapse" is-nav>
+      <b-navbar-nav>
+        <b-nav-item
+          :active="
+            $route.path.match('/data')
+              ? $route.path.match('/data').length > 0
+              : false
+          "
+          :to="{ name: 'Data' }"
+          >Data</b-nav-item
+        >
+        <b-nav-item
+          :active="
+            $route.path.match('/security')
+              ? $route.path.match('/security').length > 0
+              : false
+          "
+          v-if="hasSecurityRights()"
+          :to="{ name: 'Security' }"
+        >
+          Security
+        </b-nav-item>
+      </b-navbar-nav>
+      <b-navbar-nav class="ml-auto">
+        <b-nav-text class="mr-2 text-white">
+          <b>{{ currentUserName }}</b> on
+        </b-nav-text>
+        <environment-switch
+          :blend-color="true"
+          style="display: inline-flex"
+          @environment::importEnv="importEnv"
+          @environment::create="editEnvironment"
+          @environment::delete="deleteEnvironment"
         />
-      </b-navbar-brand>
-      <b-navbar-toggle target="nav-collapse" type="light"></b-navbar-toggle>
-      <b-collapse id="nav-collapse" is-nav>
-        <b-navbar-nav>
-          <b-nav-item
-            :active="
-              $route.path.match('/data')
-                ? $route.path.match('/data').length > 0
-                : false
-            "
-            :to="{ name: 'Data' }"
-            >Data</b-nav-item
-          >
-          <b-nav-item
-            :active="
-              $route.path.match('/security')
-                ? $route.path.match('/security').length > 0
-                : false
-            "
-            v-if="hasSecurityRights()"
-            :to="{ name: 'Security' }"
-          >
-            Security
-          </b-nav-item>
-        </b-navbar-nav>
-        <b-navbar-nav class="ml-auto">
-          <b-nav-text class="mr-2 text-white">
-            <b>{{ currentUserName }}</b> on
-          </b-nav-text>
-          <environment-switch
-            :blend-color="true"
-            style="display: inline-flex"
-            @environment::importEnv="importEnv"
-            @environment::create="editEnvironment"
-            @environment::delete="deleteEnvironment"
-          />
-          <b-nav-item class="ml-1">
-            <a title="Logout" @click="doLogout"
-              ><i class="logout fas fa-power-off"
-            /></a>
-          </b-nav-item>
-        </b-navbar-nav>
-      </b-collapse>
-    </b-navbar>
-  </div>
+        <b-nav-item class="ml-1">
+          <a title="Logout" @click="doLogout"
+            ><i class="logout fas fa-power-off"
+          /></a>
+        </b-nav-item>
+      </b-navbar-nav>
+    </b-collapse>
+  </b-navbar>
 </template>
 
 <script>
@@ -78,11 +75,6 @@ export default {
 
       return this.$store.direct.getters.kuzzle.currentEnvironment.color
     },
-
-    versionColor() {
-      return shadeColor2(this.currentEnvironmentColor, 0.5)
-    },
-
     currentUserName() {
       if (this.$store.direct.state.auth.user) {
         if (
@@ -118,28 +110,6 @@ export default {
       this.$emit('environment::delete', id)
     }
   }
-}
-
-function shadeColor2(color, percent) {
-  // https://stackoverflow.com/questions/41173998/is-it-possible-to-use-the-computed-properties-to-compute-another-properties-in-v
-  var f, t, p, R, G, B
-  f = parseInt(color.slice(1), 16)
-  t = percent < 0 ? 0 : 255
-  p = percent < 0 ? percent * -1 : percent
-  R = f >> 16
-  G = (f >> 8) & 0x00ff
-  B = f & 0x0000ff
-  return (
-    '#' +
-    (
-      0x1000000 +
-      (Math.round((t - R) * p) + R) * 0x10000 +
-      (Math.round((t - G) * p) + G) * 0x100 +
-      (Math.round((t - B) * p) + B)
-    )
-      .toString(16)
-      .slice(1)
-  )
 }
 </script>
 

--- a/src/components/Data/Layout.vue
+++ b/src/components/Data/Layout.vue
@@ -1,35 +1,33 @@
 <template>
-  <b-container fluid class="p-0 h-100">
-    <b-row no-gutters class="h-100">
-      <div class="sidebar">
-        <treeview
-          :route-name="$route.name"
-          :index="$route.params.index"
-          :collection="$route.params.collection"
-        />
-      </div>
-      <div class="content">
-        <router-view
-          v-if="routeExist"
-          :index="$route.params.index"
-          :collection="$route.params.collection"
-        />
-        <notFound v-else />
-      </div>
-    </b-row>
-  </b-container>
+  <div class="DataLayout">
+    <div class="DataLayout-sidebarWrapper">
+      <treeview
+        :route-name="$route.name"
+        :index="$route.params.index"
+        :collection="$route.params.collection"
+      />
+    </div>
+    <div class="DataLayout-contentWrapper">
+      <router-view
+        v-if="routeExist"
+        :index="$route.params.index"
+        :collection="$route.params.collection"
+      />
+      <!--<notFound v-else /> -->
+    </div>
+  </div>
 </template>
 
 <script>
 import { canSearchIndex } from '../../services/userAuthorization'
 import Treeview from './Leftnav/Treeview'
-import NotFound from './Data404'
+// import NotFound from './Data404'
 
 export default {
   name: 'DataLayout',
   components: {
-    Treeview,
-    NotFound
+    Treeview
+    // NotFound
   },
   data() {
     return {
@@ -108,19 +106,22 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.sidebar {
-  background: #fff;
-  width: $sidebar-width;
-  position: fixed;
-  top: 0;
-  padding-top: $navbar-height;
-  overflow-y: auto;
+.DataLayout {
   height: 100%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+}
+.DataLayout-sidebarWrapper {
+  flex-basis: $sidebar-width;
+  height: 100%;
+  overflow: auto;
 }
 
-.content {
-  width: calc(100% - #{$sidebar-width});
-  margin-left: $sidebar-width;
+.DataLayout-contentWrapper {
+  flex-grow: 1;
+  height: 100%;
+  overflow: auto;
   padding: $content-gutter;
 }
 </style>

--- a/src/components/Data/Layout.vue
+++ b/src/components/Data/Layout.vue
@@ -13,7 +13,7 @@
         :index="$route.params.index"
         :collection="$route.params.collection"
       />
-      <!--<notFound v-else /> -->
+      <notFound v-else />
     </div>
   </div>
 </template>
@@ -21,13 +21,13 @@
 <script>
 import { canSearchIndex } from '../../services/userAuthorization'
 import Treeview from './Leftnav/Treeview'
-// import NotFound from './Data404'
+import NotFound from './Data404'
 
 export default {
   name: 'DataLayout',
   components: {
-    Treeview
-    // NotFound
+    Treeview,
+    NotFound
   },
   data() {
     return {

--- a/src/components/Data/Layout.vue
+++ b/src/components/Data/Layout.vue
@@ -116,6 +116,7 @@ export default {
   flex-basis: $sidebar-width;
   height: 100%;
   overflow: auto;
+  box-shadow: 0px 0px 5px 0px rgba(112, 112, 112, 1);
 }
 
 .DataLayout-contentWrapper {

--- a/src/components/Data/Layout.vue
+++ b/src/components/Data/Layout.vue
@@ -125,6 +125,6 @@ export default {
   height: 100%;
   overflow: auto;
   padding: $content-gutter;
-  background-color: #f5f5f5;
+  background-color: $light-grey-color;
 }
 </style>

--- a/src/components/Data/Layout.vue
+++ b/src/components/Data/Layout.vue
@@ -117,6 +117,7 @@ export default {
   height: 100%;
   overflow: auto;
   box-shadow: 0px 0px 5px 0px rgba(112, 112, 112, 1);
+  z-index: 1;
 }
 
 .DataLayout-contentWrapper {
@@ -124,5 +125,6 @@ export default {
   height: 100%;
   overflow: auto;
   padding: $content-gutter;
+  background-color: #f5f5f5;
 }
 </style>

--- a/src/components/Data/Leftnav/IndexBranch.vue
+++ b/src/components/Data/Leftnav/IndexBranch.vue
@@ -7,9 +7,10 @@
       @click="toggleBranch"
     />
     <router-link
-      :to="{ name: 'DataIndexSummary', params: { index: indexName } }"
+      data-cy="Treeview-item"
       class="tree-item truncate"
       :class="{ active: isIndexActive(indexName) }"
+      :to="{ name: 'DataIndexSummary', params: { index: indexName } }"
     >
       <i class="fa fa-database" aria-hidden="true" />
       <span v-html="highlight(indexName, filter)" /> ({{ collectionCount }})
@@ -17,13 +18,14 @@
     <b-nav vertical class="collections">
       <b-nav-item
         v-for="collectionName in orderedFilteredStoredCollections"
+        class="tree-item truncate"
+        data-cy="Treeview-item"
+        :class="{ active: isCollectionActive(indexName, collectionName) }"
         :key="collectionName"
         :to="{
           name: 'DataDocumentsList',
           params: { index: indexName, collection: collectionName }
         }"
-        class="tree-item truncate"
-        :class="{ active: isCollectionActive(indexName, collectionName) }"
       >
         <i
           class="fa fa-th-list"
@@ -34,13 +36,14 @@
       </b-nav-item>
       <b-nav-item
         v-for="collectionName in orderedFilteredRealtimeCollections"
-        :key="collectionName"
         class="tree-item"
+        data-cy="Treeview-item"
+        :class="{ active: isCollectionActive(indexName, collectionName) }"
+        :key="collectionName"
         :to="{
           name: 'DataCollectionWatch',
           params: { index: indexName, collection: collectionName }
         }"
-        :class="{ active: isCollectionActive(indexName, collectionName) }"
       >
         <i class="fa fa-bolt" aria-hidden="true" title="Volatile collection" />
         <span v-html="highlight(collectionName, filter)" />

--- a/src/components/Data/Leftnav/Treeview.vue
+++ b/src/components/Data/Leftnav/Treeview.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="h-100">
+  <aside class="Treeview h-100">
     <b-nav vertical>
       <b-nav-item v-if="!canSearchIndex()">
         <i class="fa fa-lock" aria-hidden="true" />

--- a/src/components/Error/KuzzleErrorPage.vue
+++ b/src/components/Error/KuzzleErrorPage.vue
@@ -1,38 +1,37 @@
 <template>
-  <div>
-    <div class="row">
-      <div class="col offset-s4 s2">
-        <environment-switch
-          @environment::create="editEnvironment"
-          @environment::delete="deleteEnvironment"
-          @environment::importEnv="importEnv"
+  <div class="KuzzleErrorPage">
+    <b-jumbotron>
+      <template v-slot:header>
+        <img
+          alt="Welcome to the Kuzzle Admin Console"
+          class="mb-3"
+          height="60"
+          src="../../assets/logo.svg"
         />
-      </div>
-    </div>
-    <div class="row message-warning">
-      <h5>{{ $store.state.kuzzle.errorFromKuzzle }}</h5>
-    </div>
-    <div class="row kuzzle-disconnected">
-      <div class="col s12">
-        <p>Trying to connect to Kuzzle...</p>
-      </div>
+        <h2>{{ $store.state.kuzzle.errorFromKuzzle }}</h2>
+      </template>
 
-      <div class="col s1 offset-s5">
-        <div class="preloader-wrapper active valign-wrapper">
-          <div class="spinner-layer">
-            <div class="circle-clipper left">
-              <div class="circle" />
-            </div>
-            <div class="gap-patch">
-              <div class="circle" />
-            </div>
-            <div class="circle-clipper right">
-              <div class="circle" />
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+      <hr class="my-4" />
+
+      <b-row align-v="center">
+        <b-col sm="1">
+          <b-spinner variant="secondary" label="Spinning"> </b-spinner
+        ></b-col>
+        <b-col sm="7" class="align-middle"
+          >Trying to connect to Kuzzle...</b-col
+        >
+        <b-col sm="2" class="text-right">
+          <span class="text-muted align-middle">Connection:</span>
+        </b-col>
+        <b-col sm="2" class="text-right">
+          <environment-switch
+            @environment::create="editEnvironment"
+            @environment::delete="deleteEnvironment"
+            @environment::importEnv="importEnv"
+          />
+        </b-col>
+      </b-row>
+    </b-jumbotron>
   </div>
 </template>
 

--- a/src/components/Error/Layout.vue
+++ b/src/components/Error/Layout.vue
@@ -1,39 +1,22 @@
 <template>
-  <div class="container-error">
-    <div class="container">
-      <div class="row">
-        <div class="col card wrapper s6 offset-s3">
-          <div class="col s12">
-            <h1 class="center-align logo">
-              <img src="../../assets/logo.svg" alt="Kuzzle Backoffice" />
-            </h1>
-          </div>
+  <div class="Error">
+    <b-container>
+      <b-card>
+        <b-card-body>
           <slot>
             An error occurred.
           </slot>
-        </div>
-      </div>
-    </div>
+        </b-card-body>
+      </b-card>
+    </b-container>
   </div>
 </template>
 
 <style lang="scss" rel="stylesheet/scss" scoped>
-.container-error {
-  position: fixed;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  padding-top: 50px;
-  height: 100%;
-
-  .logo {
-    margin-top: 40px;
-    margin-bottom: 25px;
-
-    img {
-      width: 70%;
-    }
-  }
+.Error {
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 </style>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -24,7 +24,7 @@
     <div class="Home-routeWrapper">
       <router-view />
     </div>
-    <!-- <modal
+    <b-modal
       id="tokenExpired"
       class="small-modal"
       :has-footer="false"
@@ -35,9 +35,9 @@
       <h5>Your session has expired</h5>
       <h6>Please, relogin</h6>
       <login-form :on-login="onLogin" />
-    </modal>
+    </b-modal>
 
-    <modal
+    <b-modal
       id="kuzzleDisconnected"
       class="small-modal"
       :has-footer="false"
@@ -50,7 +50,7 @@
         :host="$store.direct.state.kuzzle.host"
         :port="$store.direct.state.kuzzle.port"
       />
-    </modal> -->
+    </b-modal>
   </div>
 </template>
 

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -56,17 +56,15 @@
 
 <script>
 import MainMenu from './Common/MainMenu'
-// import LoginForm from './Common/Login/Form'
-// import Modal from './Materialize/Modal'
-// import KuzzleDisconnected from './Error/KuzzleDisconnected'
+import LoginForm from './Common/Login/Form'
+import KuzzleDisconnected from './Error/KuzzleDisconnected'
 
 export default {
   name: 'Home',
   components: {
-    // LoginForm,
-    MainMenu
-    // Modal,
-    // KuzzleDisconnected
+    LoginForm,
+    MainMenu,
+    KuzzleDisconnected
   },
   computed: {
     topOffset() {

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -24,32 +24,14 @@
     <div class="Home-routeWrapper">
       <router-view />
     </div>
-    <b-modal
-      id="tokenExpired"
-      class="small-modal"
-      :has-footer="false"
-      :can-close="false"
-      :is-open="tokenExpiredIsOpen"
-      :close="noop"
-    >
-      <h5>Your session has expired</h5>
-      <h6>Please, relogin</h6>
-      <login-form :on-login="onLogin" />
-    </b-modal>
 
     <b-modal
-      id="kuzzleDisconnected"
-      class="small-modal"
-      :has-footer="false"
-      :can-close="false"
-      :close="noop"
-      :is-open="kuzzleDisconnectedIsOpen"
+      id="tokenExpired"
+      hide-footer
+      title="Your session has expired"
+      v-model="tokenExpiredIsOpen"
     >
-      <h5><i class="fa fa-warning red-color" /> Can't connect to Kuzzle</h5>
-      <kuzzle-disconnected
-        :host="$store.direct.state.kuzzle.host"
-        :port="$store.direct.state.kuzzle.port"
-      />
+      <login-form :on-login="onLogin" />
     </b-modal>
   </div>
 </template>
@@ -57,31 +39,18 @@
 <script>
 import MainMenu from './Common/MainMenu'
 import LoginForm from './Common/Login/Form'
-import KuzzleDisconnected from './Error/KuzzleDisconnected'
 
 export default {
   name: 'Home',
   components: {
     LoginForm,
-    MainMenu,
-    KuzzleDisconnected
-  },
-  computed: {
-    topOffset() {
-      const topBarHeight = 66
-      const warningBarHeight = !this.$store.direct.getters.auth
-        .adminAlreadyExists
-        ? 40
-        : 0
-      return topBarHeight + warningBarHeight
-    }
+    MainMenu
   },
   data() {
     return {
       host: null,
       port: null,
-      tokenExpiredIsOpen: false,
-      kuzzleDisconnectedIsOpen: false
+      tokenExpiredIsOpen: false
     }
   },
   watch: {
@@ -89,13 +58,6 @@ export default {
       if (!valid) {
         this.tokenExpiredIsOpen = true
       }
-    },
-    '$store.direct.state.kuzzle.connectedTo'(isConnected) {
-      if (!isConnected) {
-        this.kuzzleDisconnectedIsOpen = true
-        return
-      }
-      this.kuzzleDisconnectedIsOpen = false
     }
   },
   mounted() {

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="Home">
-    <main-menu
-      @environment::create="editEnvironment"
-      @environment::delete="deleteEnvironment"
-      @environment::importEnv="importEnv"
-    />
+    <div class="Home-menuWrapper">
+      <main-menu
+        @environment::create="editEnvironment"
+        @environment::delete="deleteEnvironment"
+        @environment::importEnv="importEnv"
+      />
+    </div>
     <b-alert
       class="position-fixed fixed-bottom m-0 rounded-0 text-center"
       dismissible
@@ -22,7 +24,7 @@
     <div class="Home-routeWrapper">
       <router-view />
     </div>
-    <modal
+    <!-- <modal
       id="tokenExpired"
       class="small-modal"
       :has-footer="false"
@@ -48,23 +50,23 @@
         :host="$store.direct.state.kuzzle.host"
         :port="$store.direct.state.kuzzle.port"
       />
-    </modal>
+    </modal> -->
   </div>
 </template>
 
 <script>
 import MainMenu from './Common/MainMenu'
-import LoginForm from './Common/Login/Form'
-import Modal from './Materialize/Modal'
-import KuzzleDisconnected from './Error/KuzzleDisconnected'
+// import LoginForm from './Common/Login/Form'
+// import Modal from './Materialize/Modal'
+// import KuzzleDisconnected from './Error/KuzzleDisconnected'
 
 export default {
   name: 'Home',
   components: {
-    LoginForm,
-    MainMenu,
-    Modal,
-    KuzzleDisconnected
+    // LoginForm,
+    MainMenu
+    // Modal,
+    // KuzzleDisconnected
   },
   computed: {
     topOffset() {
@@ -125,11 +127,20 @@ export default {
 
 <style lang="scss" rel="stylesheet/scss" scoped>
 .Home {
-  height: calc(100% - #{$navbar-height});
+  height: 100%;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  justify-items: stretch;
+}
+
+.Home-menuWrapper {
+  flex-basis: 66px;
 }
 
 .Home-routeWrapper {
-  margin-top: $navbar-height;
-  height: 100%;
+  flex-grow: 1;
+  flex-basis: 300px;
+  overflow: hidden;
 }
 </style>

--- a/src/components/Signup.vue
+++ b/src/components/Signup.vue
@@ -105,7 +105,7 @@
             <b-button
               class="mr-3"
               data-cy="LoginAsAnonymous-Btn"
-              variant="outline-secondary"
+              variant="link"
               @click="loginAsGuest"
               >Login as Anonymous</b-button
             >

--- a/tests/e2e/cypress/integration/collections.spec.js
+++ b/tests/e2e/cypress/integration/collections.spec.js
@@ -1,4 +1,4 @@
-describe('Collection management', function() {
+describe('Collection management', function () {
   const kuzzleUrl = 'http://localhost:7512'
   const indexName = 'testindex'
   const collectionName = 'testcollection'
@@ -25,9 +25,9 @@ describe('Collection management', function() {
     )
   })
 
-  it('is able to create a realtime collection and access it', function() {
+  it('is able to create a realtime collection and access it', function () {
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.visit(`/#/data/${indexName}/create`)
 
     cy.get(

--- a/tests/e2e/cypress/integration/docs.spec.js
+++ b/tests/e2e/cypress/integration/docs.spec.js
@@ -1,4 +1,4 @@
-describe('Document List', function() {
+describe('Document List', function () {
   const kuzzleUrl = 'http://localhost:7512'
   const indexName = 'testindex'
   const collectionName = 'testcollection'
@@ -37,7 +37,7 @@ describe('Document List', function() {
       JSON.stringify({
         [validEnvName]: {
           name: validEnvName,
-          color: '#002835',
+          color: 'darkblue',
           host: 'localhost',
           ssl: false,
           port: 7512,
@@ -47,17 +47,17 @@ describe('Document List', function() {
     )
   })
 
-  it('sets and persists the listViewType param accessing a collection', function() {
+  it('sets and persists the listViewType param accessing a collection', function () {
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.contains('Indexes')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.url().should('contain', 'listViewType=list')
   })
 
-  it('shows list items when viewType is set to list', function() {
+  it('shows list items when viewType is set to list', function () {
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.contains('Indexes')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.get('.DocumentList-list .collection-item')
@@ -65,9 +65,9 @@ describe('Document List', function() {
       .should('have.class', 'DocumentListItem')
   })
 
-  it('sets and persists the listViewType param when switching the list view', function() {
+  it('sets and persists the listViewType param when switching the list view', function () {
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.contains('Indexes')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.get('.ListViewButtons-btn[title~="boxes"]').click()
@@ -76,9 +76,9 @@ describe('Document List', function() {
     cy.url().should('contain', 'listViewType=list')
   })
 
-  it('shows boxed items when viewType is set to boxes', function() {
+  it('shows boxed items when viewType is set to boxes', function () {
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.contains('Indexes')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.get('.ListViewButtons-btn[title~="boxes"]').click()
@@ -87,10 +87,10 @@ describe('Document List', function() {
       .should('have.class', 'DocumentBoxItem')
   })
 
-  it('remembers the list view settings when navigating from one collection to another', function() {
+  it('remembers the list view settings when navigating from one collection to another', function () {
     cy.request('PUT', `${kuzzleUrl}/${indexName}/anothercollection`)
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.contains('Indexes')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.request(
@@ -103,11 +103,11 @@ describe('Document List', function() {
       }
     )
     cy.get('.ListViewButtons-btn[title~="boxes"]').click()
-    cy.get('.Treeview-root .tree-item')
+    cy.get('[data-cy="Treeview-item"]')
       .contains('anothercollection')
       .click()
 
-    cy.get('.Treeview-root .tree-item')
+    cy.get('[data-cy="Treeview-item"]')
       .contains(collectionName)
       .click()
     cy.url().should('contain', 'listViewType=boxes')
@@ -115,7 +115,7 @@ describe('Document List', function() {
       .children()
       .should('have.class', 'DocumentBoxItem')
 
-    cy.get('.Treeview-root .tree-item')
+    cy.get('[data-cy="Treeview-item"]')
       .contains('anothercollection')
       .click()
     cy.url().should('contain', 'listViewType=list')
@@ -124,7 +124,7 @@ describe('Document List', function() {
       .should('have.class', 'DocumentListItem')
   })
 
-  it('has items with working dropdowns (even if the ID contains weird characters)', function() {
+  it('has items with working dropdowns (even if the ID contains weird characters)', function () {
     const adrienID = 'adrien maret'
     const nicoID = 'nico_juelle'
     cy.request(
@@ -147,7 +147,7 @@ describe('Document List', function() {
     )
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.contains('Indexes')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 
@@ -170,7 +170,7 @@ describe('Document List', function() {
       .contains('Delete')
   })
 
-  it('should handle the column view properly', function() {
+  it('should handle the column view properly', function () {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
@@ -182,7 +182,7 @@ describe('Document List', function() {
     )
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.contains('Indexes')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.get('.ListViewButtons-btn[title~="column"]').click()
@@ -210,7 +210,7 @@ describe('Document List', function() {
     cy.get('.centered > thead > tr > th > .fa').click()
   })
 
-  it('should handle the time series view properly', function() {
+  it('should handle the time series view properly', function () {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/myId/_create`,
@@ -240,7 +240,7 @@ describe('Document List', function() {
     )
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.contains('Indexes')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 
@@ -319,7 +319,7 @@ describe('Document update/replace', () => {
 
   it('should update a document', () => {
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.contains('Indexes')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 
@@ -364,7 +364,7 @@ describe('Document update/replace', () => {
 
   it('should replace a document', () => {
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.contains('Indexes')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 

--- a/tests/e2e/cypress/integration/environments.spec.js
+++ b/tests/e2e/cypress/integration/environments.spec.js
@@ -16,7 +16,7 @@ describe('Environments', function () {
       force: true
     })
     cy.get('[data-cy="Environment-SubmitButton"]').click()
-    cy.get(`.EnvironmentsSwitch-env[data-env=env_${fmt(newEnvName)}]`)
+    cy.get(`[data-cy="EnvironmentSwitch-env_${fmt(newEnvName)}"]`)
   })
 
   it('is able to delete an environment', function () {
@@ -26,7 +26,7 @@ describe('Environments', function () {
       JSON.stringify({
         [envToDeleteName]: {
           name: envToDeleteName,
-          color: '#002835',
+          color: 'darkblue',
           host: 'localhost',
           ssl: false,
           port: 7512,
@@ -36,11 +36,13 @@ describe('Environments', function () {
     )
     localStorage.setItem('lastConnectedEnv', envToDeleteName)
     cy.visit('/')
-    cy.get('.row > .col > .EnvironmentsSwitch > .btn-flat > .fa').click()
+    cy.get('[data-cy="EnvironmentSwitch"]').click()
 
-    cy.get('.EnvironmentsSwitch-env:nth-child(1) > .delete').click({
-      force: true
-    })
+    cy.get(`[data-cy="EnvironmentSwitch-env_${envToDeleteName}-delete"]`).click(
+      {
+        force: true
+      }
+    )
 
     cy.get('[data-cy="EnvironmentDeleteModal-envName"]').type(envToDeleteName)
     cy.get('[data-cy="EnvironmentDeleteModal-submit"]').click({ force: true })
@@ -61,9 +63,9 @@ describe('Environments', function () {
 
     cy.get('[data-cy="Environment-SubmitButton"]').click()
     cy.wait(1000)
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
 
-    cy.get('.navbar-fixed > nav').should($nav => {
+    cy.get('nav').should($nav => {
       expect($nav.attr('class')).to.contain('EnvColor--green')
     })
   })
@@ -88,8 +90,8 @@ describe('Environments', function () {
 
     cy.visit('/')
 
-    cy.get('.EnvironmentsSwitch > .btn-flat').click()
-    cy.get('.EnvironmentsSwitch-newConnectionBtn').click()
+    cy.get('[data-cy="EnvironmentSwitch"]').click()
+    cy.get('[data-cy="EnvironmentSwitch-newConnectionBtn"]').click()
 
     cy.get('[data-cy="CreateEnvironment-name"]').type(invalidEnvName, {
       force: true
@@ -101,8 +103,8 @@ describe('Environments', function () {
 
     cy.contains('Unable to connect to kuzzle server')
 
-    cy.get('.EnvironmentsSwitch > .btn-flat').click()
-    cy.get(`.EnvironmentsSwitch-env[data-env=env_${fmt(validEnvName)}]`).click()
+    cy.get('[data-cy="EnvironmentSwitch"]').click()
+    cy.get(`[data-cy="EnvironmentSwitch-env_${fmt(validEnvName)}"]`).click()
 
     cy.get('[data-cy="App-connected"]')
   })

--- a/tests/e2e/cypress/integration/indexes.spec.js
+++ b/tests/e2e/cypress/integration/indexes.spec.js
@@ -10,7 +10,7 @@ describe('Indexes', () => {
       JSON.stringify({
         [validEnvName]: {
           name: validEnvName,
-          color: '#002835',
+          color: 'darkblue',
           host: 'localhost',
           ssl: false,
           port: 7512,
@@ -24,7 +24,7 @@ describe('Indexes', () => {
     const indexName = 'testindex'
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage-createBtn').click()
     cy.get('.CreateIndexModal-name').type(indexName, {
       force: true
@@ -38,7 +38,7 @@ describe('Indexes', () => {
     cy.request('POST', `http://localhost:7512/${indexName}/_create`)
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage-createBtn')
       .should('be.visible')
       .click()
@@ -54,7 +54,7 @@ describe('Indexes', () => {
     cy.request('POST', `http://localhost:7512/${indexName}/_create`)
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
 
     cy.get(`.IndexBoxed[title=${indexName}] .IndexBoxed-dropdown`).click()
     cy.get(`.IndexBoxed[title=${indexName}] .IndexDropdown-delete`).click()

--- a/tests/e2e/cypress/integration/login.spec.js
+++ b/tests/e2e/cypress/integration/login.spec.js
@@ -11,7 +11,7 @@ describe('Login', function () {
       JSON.stringify({
         [validEnvName]: {
           name: validEnvName,
-          color: '#002835',
+          color: 'darkblue',
           host: 'localhost',
           ssl: false,
           port: 7512,

--- a/tests/e2e/cypress/integration/search.spec.js
+++ b/tests/e2e/cypress/integration/search.spec.js
@@ -1,4 +1,4 @@
-describe('Search', function() {
+describe('Search', function () {
   const kuzzleUrl = 'http://localhost:7512'
   const indexName = 'testindex'
   const collectionName = 'testcollection'
@@ -56,7 +56,7 @@ describe('Search', function() {
       JSON.stringify({
         [validEnvName]: {
           name: validEnvName,
-          color: '#002835',
+          color: 'darkblue',
           host: 'localhost',
           ssl: false,
           port: 7512,
@@ -66,7 +66,7 @@ describe('Search', function() {
     )
   })
 
-  it('perists the Quick Search query in the URL', function() {
+  it('perists the Quick Search query in the URL', function () {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
@@ -77,7 +77,7 @@ describe('Search', function() {
       }
     )
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.get('.QuickFilter-searchBar input').type('Keylogger', { delay: 60 })
@@ -85,7 +85,7 @@ describe('Search', function() {
     cy.url().should('contain', 'active=quick')
   })
 
-  it('persists the Basic Search query in the URL', function() {
+  it('persists the Basic Search query in the URL', function () {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
@@ -96,7 +96,7 @@ describe('Search', function() {
       }
     )
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.get('.QuickFilter-optionBtn').click()
@@ -117,7 +117,7 @@ describe('Search', function() {
     cy.url().should('contain', 'Blockchain')
   })
 
-  it('remembers the Quick Search query across collections', function() {
+  it('remembers the Quick Search query across collections', function () {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
@@ -149,25 +149,25 @@ describe('Search', function() {
     )
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.get('.QuickFilter-searchBar input').type('Keylogger', { delay: 250 })
     cy.wait(250)
-    cy.get('.Treeview-root .tree-item')
+    cy.get('[data-cy="Treeview-item"]')
       .contains('anothercollection')
       .click()
     cy.url().should('not.contain', 'Keylogger')
     cy.get('.DocumentListItem').should('have.length', 2)
 
-    cy.get('.Treeview-root .tree-item')
+    cy.get('[data-cy="Treeview-item"]')
       .contains(collectionName)
       .click()
     cy.url().should('contain', 'Keylogger')
     cy.get('.DocumentListItem').should('have.length', 1)
   })
 
-  it('remembers the Basic Search query across collections', function() {
+  it('remembers the Basic Search query across collections', function () {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
@@ -199,7 +199,7 @@ describe('Search', function() {
     )
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 
@@ -216,13 +216,13 @@ describe('Search', function() {
     cy.get('.BasicFilter-submitBtn').click()
     cy.get('.DocumentListItem').should('have.length', 1)
 
-    cy.get('.Treeview-root .tree-item')
+    cy.get('[data-cy="Treeview-item"]')
       .contains('anothercollection')
       .click()
     cy.url().should('not.contain', 'Keylogger')
     cy.get('.DocumentListItem').should('have.length', 2)
 
-    cy.get('.Treeview-root .tree-item')
+    cy.get('[data-cy="Treeview-item"]')
       .contains(collectionName)
       .click()
     cy.url().should('contain', 'Keylogger')
@@ -237,9 +237,9 @@ describe('Search', function() {
     )
   })
 
-  it('refreshes search when the Search button is hit twice', function() {
+  it('refreshes search when the Search button is hit twice', function () {
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.contains(`${collectionName}`)
@@ -271,7 +271,7 @@ describe('Search', function() {
     cy.get('.DocumentListItem').should('have.length', 2)
   })
 
-  it('resets the search query but not the list view type, when the RESET button is hit', function() {
+  it('resets the search query but not the list view type, when the RESET button is hit', function () {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
@@ -283,7 +283,7 @@ describe('Search', function() {
     )
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.get('.QuickFilter-searchBar input').type('Keylogger', { delay: 60 })
@@ -326,7 +326,7 @@ describe('Search', function() {
     cy.get('.DocumentBoxItem').should('have.length', 2)
   })
 
-  it('sorts the results when sorting is selected in the basic filter', function() {
+  it.only('sorts the results when sorting is selected in the basic filter', function () {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
@@ -356,7 +356,7 @@ describe('Search', function() {
     )
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 
@@ -377,20 +377,17 @@ describe('Search', function() {
     cy.get(
       '.block-content > .col > .Autocomplete > .Autocomplete-results > .Autocomplete-result:nth-child(3)'
     ).click()
-    cy.get('.BasicFilter-sortingValue')
-      .click()
-      .contains('desc')
-      .click()
+    cy.get('.BasicFilter-sortingValue select').select('desc')
 
     cy.get('.BasicFilter-submitBtn').click()
 
-    cy.get('.DocumentListItem').should(function($el) {
+    cy.get('.DocumentListItem').should(function ($el) {
       expect($el.first()).to.contain('Maret')
       expect($el.last()).to.contain('Marchesini')
     })
   })
 
-  it('sorts the results when sorting is specfied in the raw filter', function() {
+  it('sorts the results when sorting is specfied in the raw filter', function () {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
@@ -420,7 +417,7 @@ describe('Search', function() {
     )
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 
@@ -453,15 +450,15 @@ describe('Search', function() {
 
     cy.get('.RawFilter-submitBtn').click()
 
-    cy.get('.DocumentListItem').should(function($el) {
+    cy.get('.DocumentListItem').should(function ($el) {
       expect($el.first()).to.contain('Maret')
       expect($el.last()).to.contain('Marchesini')
     })
   })
 
-  it('transforms a search query from basic filter to raw filter', function() {
+  it('transforms a search query from basic filter to raw filter', function () {
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 
@@ -482,7 +479,7 @@ describe('Search', function() {
       .and('contain', 'bar')
   })
 
-  it('should show aggregations in search result when aggregations are specified in the raw filter', function() {
+  it('should show aggregations in search result when aggregations are specified in the raw filter', function () {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
@@ -492,7 +489,7 @@ describe('Search', function() {
     )
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 
@@ -523,12 +520,12 @@ describe('Search', function() {
 
     cy.get('.RawFilter-submitBtn').click()
 
-    cy.get('.DocumentListItem').should(function($el) {
+    cy.get('.DocumentListItem').should(function ($el) {
       expect($el.first()).to.contain('Aggregations')
     })
   })
 
-  it('should not show aggregations in search result when no aggregations are specified in the raw filter', function() {
+  it('should not show aggregations in search result when no aggregations are specified in the raw filter', function () {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
@@ -538,7 +535,7 @@ describe('Search', function() {
     )
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 

--- a/tests/e2e/cypress/integration/search.spec.js
+++ b/tests/e2e/cypress/integration/search.spec.js
@@ -41,7 +41,7 @@ describe('Search', function () {
     })
     cy.request(
       'POST',
-      `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
+      `${kuzzleUrl}/${indexName}/${collectionName}/marchesini/_create?refresh=wait_for`,
       {
         firstName: 'Luca',
         lastName: 'Marchesini',
@@ -326,10 +326,10 @@ describe('Search', function () {
     cy.get('.DocumentBoxItem').should('have.length', 2)
   })
 
-  it.only('sorts the results when sorting is selected in the basic filter', function () {
+  it('sorts the results when sorting is selected in the basic filter', function () {
     cy.request(
       'POST',
-      `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
+      `${kuzzleUrl}/${indexName}/${collectionName}/maret/_create?refresh=wait_for`,
       {
         firstName: 'Adrien',
         lastName: 'Maret',
@@ -338,7 +338,7 @@ describe('Search', function () {
     )
     cy.request(
       'POST',
-      `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
+      `${kuzzleUrl}/${indexName}/${collectionName}/juelle/_create?refresh=wait_for`,
       {
         firstName: 'Nicolas',
         lastName: 'Juelle',
@@ -347,7 +347,7 @@ describe('Search', function () {
     )
     cy.request(
       'POST',
-      `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
+      `${kuzzleUrl}/${indexName}/${collectionName}/bouthinon/_create?refresh=wait_for`,
       {
         firstName: 'Alexandre',
         lastName: 'Bouthinon',
@@ -382,8 +382,8 @@ describe('Search', function () {
     cy.get('.BasicFilter-submitBtn').click()
 
     cy.get('.DocumentListItem').should(function ($el) {
-      expect($el.first()).to.contain('Maret')
-      expect($el.last()).to.contain('Marchesini')
+      expect($el.first()).to.contain('maret')
+      expect($el.last()).to.contain('marchesini')
     })
   })
 

--- a/tests/e2e/cypress/integration/users.spec.js
+++ b/tests/e2e/cypress/integration/users.spec.js
@@ -1,7 +1,7 @@
-describe('Users', function() {
+describe('Users', function () {
   const kuzzleUrl = 'http://localhost:7512'
 
-  before(function() {
+  before(function () {
     cy.request('PUT', `${kuzzleUrl}/users/_mapping`, {
       properties: {
         name: { type: 'keyword' }
@@ -9,7 +9,7 @@ describe('Users', function() {
     })
   })
 
-  beforeEach(function() {
+  beforeEach(function () {
     // create environment
     const validEnvName = 'valid'
     localStorage.setItem(
@@ -27,7 +27,7 @@ describe('Users', function() {
     )
   })
 
-  it('deletes a user successfully via the dropdown menu', function() {
+  it('deletes a user successfully via the dropdown menu', function () {
     const kuid = 'dummy'
     cy.request('POST', `${kuzzleUrl}/users/${kuid}/_create?refresh=wait_for`, {
       content: {
@@ -43,7 +43,7 @@ describe('Users', function() {
     })
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.contains('Indexes')
     cy.visit('/#/security/users')
 
@@ -63,7 +63,7 @@ describe('Users', function() {
     cy.get('.CommonList').should('not.contain', kuid)
   })
 
-  it('deletes a user successfully via the checkbox and bulk delete button', function() {
+  it('deletes a user successfully via the checkbox and bulk delete button', function () {
     const kuid = 'dummy'
     cy.request('POST', `${kuzzleUrl}/users/${kuid}/_create?refresh=wait_for`, {
       content: {
@@ -79,7 +79,7 @@ describe('Users', function() {
     })
 
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.contains('Indexes')
     cy.visit('/#/security/users')
 
@@ -95,9 +95,9 @@ describe('Users', function() {
     cy.get('.CommonList').should('not.contain', kuid)
   })
 
-  it('updates the user mapping successfully', function() {
+  it('updates the user mapping successfully', function () {
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.contains('Indexes')
     cy.visit('/#/security/users/custom-mapping')
 

--- a/tests/e2e/cypress/integration/watch.spec.js
+++ b/tests/e2e/cypress/integration/watch.spec.js
@@ -60,7 +60,7 @@ describe('Watch', () => {
   it('Should properly set basic filter', () => {
     const firstName = 'Luca'
     cy.visit('/')
-    cy.get('.LoginAsAnonymous-Btn').click()
+    cy.get('[data-cy=LoginAsAnonymous-Btn]').click()
     cy.get('.IndexesPage').should('be.visible')
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.get('.CollectionTabs--watch').click()


### PR DESCRIPTION
## What does this PR do ?
Cleans the application layout following an advice from Florens Verschelde. The main blocks of the application are now `display: flex` and we do not use the window scroll bar anymore. Instead, we force the scroll bars to appear, when needed, in the inner blocks (like, for instance, the sidebar and the main content block).

### How should this be manually tested?
Check the Netlify build.

### Other changes
* Some tests have been fixed to use the new `data-cy` target selectors introduced in the previous works.
* Some error pages have been migrated

### Boyscout
* Some useless portions of code have been deleted