### PR TITLE
fix tooltip

### DIFF
--- a/src/components/Data/Documents/Views/Column.vue
+++ b/src/components/Data/Documents/Views/Column.vue
@@ -186,12 +186,14 @@
                 :id="`tooltip-target-${data.item.id}-${data.field.key}`"
                 v-if="data.value.array === true"
               >
-                <i
-                  class="fa fa-info"
-                  title="This value cannot be displayed because it contains or is
-                contained in an array."
-                />
+                <i class="fa fa-info" />
               </b-badge>
+              <b-tooltip
+                :target="`tooltip-target-${data.item.id}-${data.field.key}`"
+              >
+                This value cannot be displayed because it contains or is
+                contained in an array.
+              </b-tooltip>
             </div>
           </template>
         </b-table>

--- a/src/components/Data/Documents/Views/Column.vue
+++ b/src/components/Data/Documents/Views/Column.vue
@@ -189,6 +189,7 @@
                 <i class="fa fa-info" />
               </b-badge>
               <b-tooltip
+                placement="left"
                 :target="`tooltip-target-${data.item.id}-${data.field.key}`"
               >
                 This value cannot be displayed because it contains or is


### PR DESCRIPTION
## What does this PR do ?
On the column view, for arrays values an icon is displayed with a tooltip to tells why we can't display the value. 
This tooltip was only displayed when hovering the dot of the 'i' icon.
This pr fix that by using bootstrap vue tooltip (wich is prettier...)

### How should this be manually tested?
  - Run a kuzzle
  - Create a collection with a field containing an array of what you want.
  - Create a document with an array in that field
  - Go to admin console column view and add this field
  - hover the tooltip 

### Other changes
/

### Boyscout
/

### Screenshots (if appropriate)
/
before: 
![Capture d’écran de 2020-03-11 15-25-44](https://user-images.githubusercontent.com/44427849/76428060-7912f900-63ad-11ea-8fa7-a0bdbf3aabd3.png)

after:
![Capture d’écran de 2020-03-11 15-25-24](https://user-images.githubusercontent.com/44427849/76428069-7b755300-63ad-11ea-9053-057ed83ab19c.png)
