### PR TITLE
Kzl 1478 show spinner on document loading

### DIFF
--- a/src/components/Data/Documents/DocumentListItem.vue
+++ b/src/components/Data/Documents/DocumentListItem.vue
@@ -65,7 +65,7 @@
       <b-collapse
         :id="`collapse-${document.id}`"
         v-model="expanded"
-        class="mt-3 ml-3 DocumentListItem-content"
+        class="mt-3 ml-3 DocumentListItem-content w-100"
       >
         <pre v-json-formatter="{ content: document.content, open: true }" />
         <pre v-json-formatter="{ content: document.meta, open: false }" />

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -40,13 +40,24 @@
         <template v-else>
           <b-row class="justify-content-md-center" no-gutters>
             <b-col cols="12">
-              <template v-if="isCollectionEmpty">
+              <template v-if="isCollectionEmpty && !fetchingDocuments">
                 <realtime-only-empty-state
                   v-if="isRealtimeCollection"
                   :index="index"
                   :collection="collection"
                 />
                 <empty-state v-else :index="index" :collection="collection" />
+              </template>
+              <template v-else>
+                <b-row class="text-center">
+                  <b-col>
+                    <b-spinner
+                      v-if="fetchingDocuments"
+                      variant="primary"
+                      class="mt-5"
+                    ></b-spinner>
+                  </b-col>
+                </b-row>
               </template>
               <template v-if="!isCollectionEmpty">
                 <filters
@@ -194,6 +205,7 @@ export default {
   },
   data() {
     return {
+      fetchingDocuments: false,
       searchFilterOperands: filterManager.searchFilterOperands,
       selectedDocuments: [],
       documents: [],
@@ -450,6 +462,7 @@ export default {
       }
     },
     async fetchDocuments() {
+      this.fetchingDocuments = true
       this.$forceUpdate()
       this.indexOrCollectionNotFound = false
 
@@ -495,6 +508,7 @@ export default {
           })
         }
       }
+      this.fetchingDocuments = false
     },
 
     // PAGINATION

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -48,7 +48,7 @@
                 />
                 <empty-state v-else :index="index" :collection="collection" />
               </template>
-              <template v-else>
+              <template v-if="fetchingDocuments">
                 <b-row class="text-center">
                   <b-col>
                     <b-spinner


### PR DESCRIPTION
## What does this PR do ?

Add a spinner while fetching documents on documents view (list/column/whatever).
Actually the AC is showing 'this collection is empty'.

Cut the lines of the json view to fit the div of the document list view. 

### How should this be manually tested?

  - Run Kuzzle
  - Create some documents
  - Click on create new document button then cancel
  - It should display a spinner instead of this collection is empty

  - Create a document with a long text in a field
  - On document list view it should cut the json line instead of letting it it go over the div

### Other changes
/

### Boyscout
/

### Screenshots (if appropriate)
![Capture d’écran de 2020-03-11 17-18-19](https://user-images.githubusercontent.com/44427849/76439342-8d122700-63bc-11ea-97d0-e16eb6c03178.png)
![Capture d’écran de 2020-03-11 17-17-48](https://user-images.githubusercontent.com/44427849/76439359-93080800-63bc-11ea-972b-162310d731f1.png)
![Capture du 2020-03-05 13-58-56](https://user-images.githubusercontent.com/44427849/76439399-a3b87e00-63bc-11ea-8aad-784cd9d0017c.png)
![Capture d’écran de 2020-03-11 17-18-15](https://user-images.githubusercontent.com/44427849/76439408-a7e49b80-63bc-11ea-8b1b-1cebbd1632b3.png)

