### PR TITLE
format message wrong query

### DIFF
--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -484,6 +484,19 @@ export default {
         this.$log.error(e)
         if (e.status === 412) {
           this.indexOrCollectionNotFound = true
+        } else if (e.message.includes('failed to create query')) {
+          this.$bvToast.toast(
+            'Your query is ill-formed. The complete error has been dumped to the console.',
+            {
+              title:
+                'Ooops! Something went wrong while fetching the documents.',
+              variant: 'warning',
+              toaster: 'b-toaster-bottom-right',
+              appendTouast: true,
+              dismissible: true,
+              noAutoHide: true
+            }
+          )
         } else {
           this.$bvToast.toast(e.message, {
             title: 'Ooops! Something went wrong while fetching the documents.',


### PR DESCRIPTION


## What does this PR do ?
The toast of the error when a query was wrong displayed the entire error message. 
This Pr just makes it understandable

### How should this be manually tested?
  - Step 1 : Run Kuzzle and go on AC
  - Step 2 : If needed, create a collection and a document with a text field for example
  - Step 3 : in advanced mode query search use a maladjusted verb (ex: match for number or equal for text)
  - Step 4 : Check the toast displayed on the right bottom
  ...

### Other changes
/

### Boyscout
/


### Screenshots (if appropriate)
![Capture du 2020-03-05 14-00-12](https://user-images.githubusercontent.com/44427849/76605049-17b76b00-6510-11ea-894d-75419d7b42b9.png)
![Capture du 2020-03-13 09-37-56](https://user-images.githubusercontent.com/44427849/76605060-1d14b580-6510-11ea-9d06-3d00ddb3bd9b.png)
