### PR TITLE
[HOTFIX] Fix total documents in pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-admin-console",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-admin-console",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A handy administrative console for Kuzzle",
   "author": "The Kuzzle team <support@kuzzle.io>",
   "private": false,

--- a/src/services/kuzzleWrapper.js
+++ b/src/services/kuzzleWrapper.js
@@ -123,9 +123,11 @@ export const performSearchDocuments = async (
     throw new Error('Missing collection or index')
   }
 
+  // Use a scroll in order for ES to return the total number of document that match the search
+  // without being limited by its own limitation (10k documents)
   const result = await Vue.prototype.$kuzzle
     .document
-    .search(index, collection, { ...filters, sort }, { ...pagination })
+    .search(index, collection, { ...filters, sort }, { ...pagination, scroll: '1ms' })
 
   let additionalAttributeName = null
 


### PR DESCRIPTION
## What does this PR do ?

Use a scroll in order for ES to return the total number of document that match the search without being limited by its own limitation (10k documents).

### How should this be manually tested?

Check a collection which has more than 10K documents, you should this something like this:

![a](https://user-images.githubusercontent.com/592088/77544385-396a0800-6ea9-11ea-80a9-c47e4c91c966.png)