### PR TITLE
[KZL-1500] Paginate search results

### DIFF
--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -125,12 +125,12 @@
                       align-h="center"
                     >
                       <b-pagination
-                        class="m-2 mt-4"
                         v-model="currentPage"
                         aria-controls="my-table"
+                        class="m-2 mt-4"
+                        data-cy="DocumentList-pagination"
                         :total-rows="totalDocuments"
                         :per-page="paginationSize"
-                        @change="fetchDocuments"
                       ></b-pagination>
                     </b-row>
                   </template>

--- a/src/components/Data/Leftnav/IndexBranch.vue
+++ b/src/components/Data/Leftnav/IndexBranch.vue
@@ -1,9 +1,10 @@
 <template>
-  <div :class="{ open: open || filter }" class="index-branch mt-2">
+  <div :class="{ open: open || filter }" class="IndexBranch mt-2">
     <i
       v-if="collectionCount"
-      class="fa fa-caret-right tree-toggle"
       aria-hidden="true"
+      class="fa fa-caret-right tree-toggle"
+      :data-cy="`IndexBranch-toggle--${indexName}`"
       @click="toggleBranch"
     />
     <i v-else class="no-caret"></i>

--- a/src/components/Data/Leftnav/Treeview.vue
+++ b/src/components/Data/Leftnav/Treeview.vue
@@ -10,9 +10,10 @@
     <template v-else>
       <div class="Treeview-search p-3">
         <b-form-input
-          type="search"
           v-model="filter"
+          data-cy="Treeview-filter"
           placeholder="Search index &amp; collection"
+          type="search"
         ></b-form-input>
       </div>
       <div class="Treeview-items p-3">
@@ -26,12 +27,13 @@
         </router-link>
         <index-branch
           v-for="indexName in orderedFilteredIndices"
-          :key="indexName"
-          :index-name="indexName"
           :collections="indexesAndCollections[indexName]"
-          :current-index="index"
-          :filter="filter"
           :current-collection="collection"
+          :current-index="index"
+          :data-cy="`Treeview-item-index--${indexName}`"
+          :filter="filter"
+          :index-name="indexName"
+          :key="indexName"
         />
       </div>
     </template>
@@ -76,7 +78,6 @@ export default {
     orderedFilteredIndices() {
       return [
         ...filterIndexesByKeyword(
-          this.$store.direct.getters.index.indexes,
           this.$store.direct.state.index.indexesAndCollections,
           this.filter
         )

--- a/src/services/data.ts
+++ b/src/services/data.ts
@@ -54,7 +54,8 @@ export const generateHash = s => {
   return hash
 }
 
-export const filterIndexesByKeyword = (indexes, indexTree, word) => {
+export const filterIndexesByKeyword = (indexTree, word) => {
+  const indexes = Object.keys(indexTree)
   if (!word || word === '') {
     return indexes
   }

--- a/src/services/kuzzleWrapper.ts
+++ b/src/services/kuzzleWrapper.ts
@@ -155,7 +155,7 @@ export const performSearchDocuments = async (
     index,
     collection,
     { ...filters, sort },
-    { ...pagination, scroll: '1ms' }
+    { ...pagination }
   )
 
   let additionalAttributeName: any = null

--- a/test/e2e/cypress/integration/indexes.spec.js
+++ b/test/e2e/cypress/integration/indexes.spec.js
@@ -21,7 +21,7 @@ describe('Indexes', () => {
     localStorage.setItem('currentEnv', validEnvName)
   })
 
-  it('is able to create a new index', () => {
+  it('Should be able to create a new index', () => {
     const indexName = 'testindex'
 
     cy.waitOverlay()
@@ -34,7 +34,7 @@ describe('Indexes', () => {
     cy.contains(indexName)
   })
 
-  it('does not allow to create the same index twice', () => {
+  it('Should not allow to create the same index twice', () => {
     const indexName = 'testindex'
     cy.request('POST', `http://localhost:7512/${indexName}/_create`)
 
@@ -51,7 +51,7 @@ describe('Indexes', () => {
     cy.contains(`A public index named "${indexName}" already exists`)
   })
 
-  it('is able to delete an index', () => {
+  it('Should be able to delete an index', () => {
     const indexName = 'testindex'
     cy.request('POST', `http://localhost:7512/${indexName}/_create`)
 

--- a/test/e2e/cypress/integration/search.spec.js
+++ b/test/e2e/cypress/integration/search.spec.js
@@ -512,4 +512,44 @@ describe('Search', function() {
 
     cy.get('[data-cy="RawFilter-submitBtn"]').click()
   })
+
+  it('should properly paginate search results', () => {
+    const docCount = 50
+    const documents = []
+    for (let i = 0; i < docCount; i++) {
+      documents.push({
+        _id: `dummy-${i}`,
+        body: {
+          firstName: 'Dummy',
+          lastName: `Clone-${i}`,
+          job: 'Blockchain as a Service'
+        }
+      })
+    }
+    cy.request(
+      'POST',
+      `${kuzzleUrl}/${indexName}/${collectionName}/_mWrite?refresh=wait_for`,
+      {
+        documents
+      }
+    )
+    cy.visit(`/#/data/${indexName}/${collectionName}`)
+    cy.contains(collectionName)
+
+    cy.get('[data-cy=QuickFilter-optionBtn]').click()
+    cy.get('[data-cy=Filters-basicTab]').click()
+
+    cy.get('[data-cy="BasicFilter-attributeSelect--0.0"]').select('firstName')
+    cy.get('[data-cy="BasicFilter-valueInput--0.0"]').type('Dummy')
+    cy.get('[data-cy=BasicFilter-sortAttributeSelect]').select('lastName')
+
+    cy.get('[data-cy=BasicFilter-submitBtn]').click()
+
+    cy.get('[data-cy=DocumentList-pagination] [aria-posinset=4]').click()
+
+    cy.contains('dummy-40')
+    cy.contains('dummy-41')
+    cy.contains('dummy-42')
+    cy.url().should('contain', 'from=30')
+  })
 })

--- a/test/e2e/cypress/integration/treeview.spec.js
+++ b/test/e2e/cypress/integration/treeview.spec.js
@@ -1,0 +1,53 @@
+describe('Treeview', () => {
+  beforeEach(() => {
+    // reset all the indexes
+    cy.request('POST', 'http://localhost:7512/admin/_resetDatabase')
+
+    // create environment
+    const validEnvName = 'valid'
+    localStorage.setItem(
+      'environments',
+      JSON.stringify({
+        [validEnvName]: {
+          name: validEnvName,
+          color: 'darkblue',
+          host: 'localhost',
+          ssl: false,
+          port: 7512,
+          token: 'anonymous'
+        }
+      })
+    )
+    localStorage.setItem('currentEnv', validEnvName)
+  })
+
+  it('Should show the index and collection tree', () => {
+    const indexName = 'testindex'
+    const collectionName = 'testcollection'
+    cy.request('POST', `http://localhost:7512/${indexName}/_create`)
+    cy.request('PUT', `http://localhost:7512/${indexName}/${collectionName}`)
+    cy.waitOverlay()
+
+    cy.get(`[data-cy=Treeview-item-index--${indexName}]`).should('be.visible')
+    cy.get(`[data-cy=IndexBranch-toggle--${indexName}]`).click()
+    cy.get(`[data-cy=Treeview-item--${collectionName}]`).should('be.visible')
+  })
+
+  it('Should be able to filter indexes and collections', () => {
+    const indexes = ['totoindex', 'lolindex']
+    const collections = ['foocollection', 'barcollection']
+
+    for (let i = 0; i < 2; i++) {
+      cy.request('POST', `http://localhost:7512/${indexes[i]}/_create`)
+      cy.request('PUT', `http://localhost:7512/${indexes[i]}/${collections[i]}`)
+    }
+    cy.waitOverlay()
+
+    cy.get('[data-cy=Treeview-filter]').type(collections[1])
+    cy.get(`[data-cy=Treeview-item-index--${indexes[1]}]`).should('be.visible')
+    cy.get(`[data-cy=Treeview-item--${collections[1]}]`).should('be.visible')
+
+    cy.get('[data-cy=Treeview-filter]').type(`{selectall}${indexes[0]}`)
+    cy.get(`[data-cy=Treeview-item-index--${indexes[0]}]`).should('be.visible')
+  })
+})


### PR DESCRIPTION
Fixes [KZL-1500](https://jira.kaliop.net/browse/KZL-1500) and a critical bug of the Treeview.

### How should this be manually tested?

* Create a lot of documents
* Perform a search that return at least 11 documents
* Go to page 2 and verify it's working

### Other changes
Had to take out the `scroll: '1ms'` in the `performSearchDocuments` action of the `kuzzleWrapper.ts` file, since pagination is not allowed by Elasticsearch in a scroll context (`using [from] is not allowed in a scroll context`).

### Boyscout
* Fixed a major bug in the Treeview that prevented it from render