### PR TITLE
[HOTFIX] Fix total documents in pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-admin-console",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-admin-console",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A handy administrative console for Kuzzle",
   "author": "The Kuzzle team <support@kuzzle.io>",
   "private": false,

--- a/src/services/kuzzleWrapper.js
+++ b/src/services/kuzzleWrapper.js
@@ -127,7 +127,11 @@ export const performSearchDocuments = async (
   // without being limited by its own limitation (10k documents)
   const result = await Vue.prototype.$kuzzle
     .document
-    .search(index, collection, { ...filters, sort }, { ...pagination, scroll: '1ms' })
+    .search(index, collection, { ...filters, sort }, { ...pagination })
+
+  const totalDocument = await Vue.prototype.$kuzzle
+    .document
+    .count(index, collection, { ...filters })
 
   let additionalAttributeName = null
 
@@ -162,7 +166,7 @@ export const performSearchDocuments = async (
 
     return object
   })
-  return { documents, total: result.total }
+  return { documents, total: totalDocument }
 }
 
 export const getMappingDocument = (collection, index) => {

--- a/src/services/kuzzleWrapper.js
+++ b/src/services/kuzzleWrapper.js
@@ -131,7 +131,7 @@ export const performSearchDocuments = async (
 
   const totalDocument = await Vue.prototype.$kuzzle
     .document
-    .count(index, collection, { ...filters })
+    .count(index, collection, { query: filters.query })
 
   let additionalAttributeName = null
 

--- a/test/unit/specs/services/kuzzleWrapper.spec.js
+++ b/test/unit/specs/services/kuzzleWrapper.spec.js
@@ -66,6 +66,9 @@ describe('Kuzzle wrapper service', () => {
                       resolve(fakeResponse)
                     }
                   })
+                },
+                count() {
+                  return new Promise(resolve => resolve(42))
                 }
               }
             }


### PR DESCRIPTION
## What does this PR do ?

A regression has been introduced by https://github.com/kuzzleio/kuzzle-admin-console/pull/632 where we use a scroll to have the real total document but with this solution we cannot use the pagination anymore (from and size).
To fix this we now call document:count to get the total document.