### PR TITLE
reset password form

### DIFF
--- a/src/components/Common/Login/Form.vue
+++ b/src/components/Common/Login/Form.vue
@@ -95,7 +95,22 @@ export default {
         })
         this.onLogin() // TODO change this to $emit
       } catch (err) {
-        this.error = err.message
+        if (
+          [
+            'plugin.kuzzle-plugin-auth-passport-local.expired_password',
+            'plugin.kuzzle-plugin-auth-passport-local.must_change_password'
+          ].includes(err.id)
+        ) {
+          this.$router.push({
+            name: 'ResetPassword',
+            params: {
+              showIntro: true,
+              token: err.resetToken
+            }
+          })
+        } else {
+          this.error = err.message
+        }
       }
     },
     loginAsAnonymous() {

--- a/src/components/Common/Login/ResetPasswordForm.vue
+++ b/src/components/Common/Login/ResetPasswordForm.vue
@@ -1,0 +1,101 @@
+<template>
+  <form id="resetPasswordForm" method="post" @submit.prevent="resetPassword()">
+    <div class="resetPasswordForm-inputs">
+      <b-form-group
+        label="New password"
+        label-for="password"
+        label-cols-sm="4"
+        label-cols-md="3"
+      >
+        <b-form-input
+          autofocus
+          class="validate"
+          data-cy="ResetPassword-password"
+          id="password"
+          name="password"
+          required
+          tabindex="1"
+          type="password"
+          v-model="password"
+        />
+      </b-form-group>
+
+      <b-form-group
+        description="Re-type the password for confirmation"
+        label="Confirm password"
+        label-cols-sm="4"
+        label-cols-lg="3"
+        label-for="password2"
+      >
+        <b-input
+          class="validate"
+          data-cy="ResetPassword-password2"
+          id="password2"
+          name="password2"
+          required
+          tabindex="2"
+          type="password"
+          v-model="password2"
+        />
+      </b-form-group>
+
+      <div class="ResetPasswordForm-error" v-if="error">
+        <b-alert variant="danger" show dismissible>
+          Error: {{ error }}
+        </b-alert>
+      </div>
+
+      <div class="ResetPasswordForm-buttons float-right mt-3">
+        <b-button
+          variant="primary"
+          data-cy="ResetPassword-submitBtn"
+          type="submit"
+          name="action"
+          tabindex="3"
+          >Send</b-button
+        >
+      </div>
+    </div>
+  </form>
+</template>
+
+<script>
+export default {
+  name: 'ResetPasswordForm',
+  props: {
+    resetToken: String
+  },
+  data() {
+    return {
+      error: '',
+      password: '',
+      password2: ''
+    }
+  },
+  methods: {
+    async resetPassword() {
+      this.error = ''
+
+      if (this.password.trim() === '' || this.password2.trim() === '') {
+        this.error = 'All fields are mandatory'
+        return
+      }
+
+      if (this.password !== this.password2) {
+        this.error = 'Passwords do not match'
+        return
+      }
+
+      try {
+        await this.$store.direct.dispatch.auth.doResetPassword({
+          password: this.password,
+          token: this.$route.params.token
+        })
+        this.$emit('reset-password::after')
+      } catch (error) {
+        this.error = error.message
+      }
+    }
+  }
+}
+</script>

--- a/src/components/Common/Login/ResetPasswordForm.vue
+++ b/src/components/Common/Login/ResetPasswordForm.vue
@@ -1,7 +1,12 @@
 <template>
-  <form id="resetPasswordForm" method="post" @submit.prevent="resetPassword()">
+  <form
+    id="resetPasswordForm"
+    method="post"
+    @submit.prevent="resetPassword()"
+  >
     <div class="resetPasswordForm-inputs">
       <b-form-group
+        invalid-feedback="Password must not be empty"
         label="New password"
         label-for="password"
         label-cols-sm="4"
@@ -13,10 +18,12 @@
           data-cy="ResetPassword-password"
           id="password"
           name="password"
+          pattern=".*[^ ].*"
           required
           tabindex="1"
           type="password"
           v-model="password"
+          @blur="setValidated"
         />
       </b-form-group>
 
@@ -26,6 +33,7 @@
         label-cols-sm="4"
         label-cols-lg="3"
         label-for="password2"
+        :invalid-feedback="password2Feedback"
       >
         <b-input
           class="validate"
@@ -36,6 +44,8 @@
           tabindex="2"
           type="password"
           v-model="password2"
+          :pattern="password2Pattern"
+          @blur="setValidated"
         />
       </b-form-group>
 
@@ -72,29 +82,36 @@ export default {
       password2: ''
     }
   },
+  computed: {
+    password2Feedback() {
+      if (this.password !== this.password2) {
+        return 'Passwords do not match'
+      }
+      return 'Password must not be empty'
+    },
+    password2Pattern() {
+      // html validation pattern use regular expressions
+      // We need to escape special chars to match against the password field
+      // taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+      return this.password.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&')
+    }
+  },
   methods: {
     async resetPassword() {
       this.error = ''
 
-      if (this.password.trim() === '' || this.password2.trim() === '') {
-        this.error = 'All fields are mandatory'
-        return
-      }
-
-      if (this.password !== this.password2) {
-        this.error = 'Passwords do not match'
-        return
-      }
-
       try {
         await this.$store.direct.dispatch.auth.doResetPassword({
           password: this.password,
-          token: this.$route.params.token
+          token: this.resetToken
         })
         this.$emit('reset-password::after')
       } catch (error) {
         this.error = error.message
       }
+    },
+    setValidated(event) {
+      event.target.parentNode.classList.add('was-validated')
     }
   }
 }

--- a/src/components/Common/Login/ResetPasswordForm.vue
+++ b/src/components/Common/Login/ResetPasswordForm.vue
@@ -1,9 +1,5 @@
 <template>
-  <form
-    id="resetPasswordForm"
-    method="post"
-    @submit.prevent="resetPassword()"
-  >
+  <form id="resetPasswordForm" method="post" @submit.prevent="resetPassword()">
     <div class="resetPasswordForm-inputs">
       <b-form-group
         invalid-feedback="Password must not be empty"

--- a/src/components/ConnectionAwareContainer.vue
+++ b/src/components/ConnectionAwareContainer.vue
@@ -107,6 +107,10 @@ export default {
       }
     },
     async authenticationGuard() {
+      if (this.$route.meta.skipLogin) {
+        return
+      }
+
       // NOTE (@xbill82) this is duplicated code from the router. I tried to reuse
       // the code from router.authenticationGuard by refactoring it into a separate
       // function, but I can't pass `this.$router.push` as the `next` parameter:

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -66,12 +66,11 @@ export default {
       window.document.body.style.overflow = 'visible'
 
       if (this.$store.getters.routeBeforeRedirect) {
+        this.$store.direct.commit.routing.setRouteBeforeRedirect(undefined)
         this.$router.push({ name: this.$store.getters.routeBeforeRedirect })
       } else {
-        this.$router.push('/').catch(() => {})
+        this.$router.push('/')
       }
-
-      this.$store.direct.commit.routing.setRouteBeforeRedirect(undefined)
     },
     editEnvironment(id) {
       this.$emit('environment::create', id)

--- a/src/components/ResetPassword.vue
+++ b/src/components/ResetPassword.vue
@@ -43,12 +43,11 @@ export default {
   methods: {
     onReset() {
       if (this.$store.getters.routeBeforeRedirect) {
+        this.$store.direct.commit.routing.setRouteBeforeRedirect(undefined)
         this.$router.push({ name: this.$store.getters.routeBeforeRedirect })
       } else {
-        this.$router.push('/').catch(() => {})
+        this.$router.push('/')
       }
-
-      this.$store.direct.commit.routing.setRouteBeforeRedirect(undefined)
     }
   }
 }

--- a/src/components/ResetPassword.vue
+++ b/src/components/ResetPassword.vue
@@ -16,14 +16,14 @@
               class="text-center"
               variant="warning"
               data-cy="resetPasswordAlert"
-              :show="$route.params.showIntro"
+              :show="showIntro"
             >
               <b>Warning!</b> You must update your password to continue
             </b-alert>
           </b-card-body>
 
           <reset-password-form
-            :reset-token="$route.params.token"
+            :reset-token="token"
             @reset-password::after="onReset"
           />
         </b-card>
@@ -37,6 +37,10 @@ import ResetPasswordForm from './Common/Login/ResetPasswordForm'
 
 export default {
   name: 'ResetPassword',
+  props: {
+    showIntro: Boolean,
+    token: String
+  },
   components: {
     ResetPasswordForm
   },

--- a/src/components/ResetPassword.vue
+++ b/src/components/ResetPassword.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="LoginPage">
+    <b-row align-h="center" class="w-100">
+      <b-col xl="6" lg="7" md="8" sm="10">
+        <b-card>
+          <b-card-body>
+            <div class="text-center">
+              <img
+                src="../assets/logo.svg"
+                alt="Welcome to the Kuzzle Admin Console"
+                class="mb-5 img-fluid"
+              />
+            </div>
+
+            <b-alert
+              class="text-center"
+              variant="warning"
+              data-cy="resetPasswordAlert"
+              :show="$route.params.showIntro"
+            >
+              <b>Warning!</b> You must update your password to continue
+            </b-alert>
+          </b-card-body>
+
+          <reset-password-form
+            :reset-token="$route.params.token"
+            @reset-password::after="onReset"
+          />
+        </b-card>
+      </b-col>
+    </b-row>
+  </div>
+</template>
+
+<script>
+import ResetPasswordForm from './Common/Login/ResetPasswordForm'
+
+export default {
+  name: 'ResetPassword',
+  components: {
+    ResetPasswordForm
+  },
+  methods: {
+    onReset() {
+      if (this.$store.getters.routeBeforeRedirect) {
+        this.$router.push({ name: this.$store.getters.routeBeforeRedirect })
+      } else {
+        this.$router.push('/').catch(() => {})
+      }
+
+      this.$store.direct.commit.routing.setRouteBeforeRedirect(undefined)
+    }
+  }
+}
+</script>

--- a/src/components/Signup.vue
+++ b/src/components/Signup.vue
@@ -189,17 +189,25 @@ export default {
         this.$store.direct.commit.auth.setAdminExists(true)
         this.$router.push({ name: 'Login' })
       } catch (err) {
-        this.$log.error(err)
-        this.$bvToast.toast(
-          'The complete error has been printed to the console.',
-          {
-            title:
-              'Ooops! Something went wrong while creating the administrator.',
-            variant: 'danger',
-            toaster: 'b-toaster-bottom-right',
-            appendToast: true
-          }
-        )
+        if (
+          [
+            'plugin.kuzzle-plugin-auth-passport-local.login_in_password',
+            'plugin.kuzzle-plugin-auth-passport-local.weak_password'
+          ].includes(err.id)
+        ) {
+          this.error = err.message
+        } else {
+          this.$log.error(err)
+          this.$bvToast.toast(
+            'The complete error has been printed to the console.',
+            {
+              title: err.message,
+              variant: 'danger',
+              toaster: 'b-toaster-bottom-right',
+              appendToast: true
+            }
+          )
+        }
       }
       this.waiting = false
     },

--- a/src/directives/Materialize/m-select.directive.ts
+++ b/src/directives/Materialize/m-select.directive.ts
@@ -9,7 +9,7 @@ export default {
     setTimeout(() => {
       $el.material_select()
       // $el.on('change', () => {
-        // this.set(el.value)
+      // this.set(el.value)
       // })
     }, 0)
   }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -10,6 +10,7 @@ import Home from '../components/Home.vue'
 import Login from '../components/Login.vue'
 import Signup from '../components/Signup.vue'
 import DataLayout from '../components/Data/Layout.vue'
+import ResetPassword from '../components/ResetPassword.vue'
 import SecurityLayout from '../components/Security/Layout.vue'
 
 import SecuritySubRoutes from './children/security'
@@ -89,9 +90,20 @@ export default function createRoutes(log, kuzzle) {
             component: Login
           },
           {
+            path: '/reset-password/:token',
+            name: 'ResetPassword',
+            component: ResetPassword,
+            meta: {
+              skipLogin: true
+            }
+          },
+          {
             path: '/signup',
             name: 'Signup',
-            component: Signup
+            component: Signup,
+            meta: {
+              skipLogin: true
+            }
           },
           {
             path: '/',

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -95,7 +95,8 @@ export default function createRoutes(log, kuzzle) {
             component: ResetPassword,
             meta: {
               skipLogin: true
-            }
+            },
+            props: true
           },
           {
             path: '/signup',

--- a/src/vuex/modules/auth/store.ts
+++ b/src/vuex/modules/auth/store.ts
@@ -153,6 +153,20 @@ const actions = createActions({
     commit.setCurrentUser(new SessionUser())
     commit.setTokenValid(false)
     return dispatch.checkFirstAdmin()
+  },
+  async doResetPassword(context, data) {
+    const { dispatch } = authActionContext(context)
+    Vue.prototype.$kuzzle.jwt = null
+
+    const request = {
+      controller: 'kuzzle-plugin-auth-passport-local/password',
+      action: 'reset',
+      body: data
+    }
+
+    const response = await Vue.prototype.$kuzzle.query(request)
+    const jwt = response.result.jwt
+    return dispatch.prepareSession(jwt)
   }
 })
 

--- a/src/vuex/modules/collection/types.ts
+++ b/src/vuex/modules/collection/types.ts
@@ -1,9 +1,9 @@
 export interface CollectionState {
-  name?: string,
-  mapping: object,
-  isRealtimeOnly: boolean,
-  schema: object,
-  allowForm: boolean,
+  name?: string
+  mapping: object
+  isRealtimeOnly: boolean
+  schema: object
+  allowForm: boolean
   defaultViewJson: boolean
 }
 

--- a/src/vuex/types.ts
+++ b/src/vuex/types.ts
@@ -1,3 +1,2 @@
 // types.ts
-export interface RootState {
-}
+export interface RootState {}


### PR DESCRIPTION
## What does this PR do ?

This PR implements the new up-coming features from https://github.com/kuzzleio/kuzzle-plugin-auth-passport-local/pull/70.

- implement a reset password form
- handle `expired_password` and `must_change_password` errors on login and redirect to reset password form in this case
- make sure other custom errors are properly handled

### How should this be manually tested?

```
git clone -b password-policies git@github.com:kuzzleio/kuzzle-plugin-auth-passport-local.git
docker-compose up -d
docker-compose exec kuzzle sh -c 'echo \'{
  "plugins": {
    "kuzzle-plugin-auth-passport-local": {
      "passwordPolicies": [
        {
          "appliesTo": "*",
          "expiresAfter": "42 mn",
          "forbidLoginInPassword": true,
          "forbidReusedPasswordCount": 24,
          "mustChangePasswordIfSetByAdmin": true,
          "passwordRegex": ".{5,}"
        }
      ]
    }
  }
}\' > /var/app/.kuzzlerc && touch /var/app/plugins/available/kuzzle-plugin-auth-passport-local/index.js'
```

To get a reset token: 
```
curl -s http://localhost:7512/_plugin/kuzzle-plugin-auth-passport-local/password/resetToken/admin | docker run -i stedolan/jq -r '.result.resetToken'
```

You can now access the reset password form on `/#/reset-password/<token>`

### Screenshots (if appropriate)

When `expired_password` or `must_change_password` error received on login:

![image](https://user-images.githubusercontent.com/6680551/80478635-14f0c800-894e-11ea-8732-56f469534722.png)

Direct access (for instance when coming from a "forgot password" email):

![image](https://user-images.githubusercontent.com/6680551/80478807-571a0980-894e-11ea-9e98-df51f8cc39e0.png)

![image](https://user-images.githubusercontent.com/6680551/80478886-7b75e600-894e-11ea-9c51-6578717a10af.png)

![image](https://user-images.githubusercontent.com/6680551/80483559-951b2b80-8956-11ea-89a3-d3eff98d173a.png)
