### PR TITLE
Change document fields order

### DIFF
--- a/src/components/Data/Documents/DocumentListItem.vue
+++ b/src/components/Data/Documents/DocumentListItem.vue
@@ -67,7 +67,7 @@
         v-model="expanded"
         class="ml-3 DocumentListItem-content w-100"
       >
-        <pre v-json-formatter="{ content: formatedDocument, open: true }" />
+        <pre v-json-formatter="{ content: formattedDocument, open: true }" />
       </b-collapse>
     </b-row>
   </b-container>

--- a/src/components/Data/Documents/DocumentListItem.vue
+++ b/src/components/Data/Documents/DocumentListItem.vue
@@ -67,13 +67,14 @@
         v-model="expanded"
         class="ml-3 DocumentListItem-content w-100"
       >
-        <pre v-json-formatter="{ content: document, open: true }" />
+        <pre v-json-formatter="{ content: formatedDocument, open: true }" />
       </b-collapse>
     </b-row>
   </b-container>
 </template>
 
 <script>
+import _ from 'lodash'
 import JsonFormatter from '../../../directives/json-formatter.directive'
 import {
   canEditDocument,
@@ -121,6 +122,11 @@ export default {
     },
     checkboxId() {
       return `checkbox-${this.document.id}`
+    },
+    formatedDocument () {
+      const document = _.omit(this.document, ['id', '_kuzzle_info'])
+      document._kuzzle_info = this.document._kuzzle_info
+      return document
     }
   },
   methods: {

--- a/src/components/Data/Documents/DocumentListItem.vue
+++ b/src/components/Data/Documents/DocumentListItem.vue
@@ -123,7 +123,11 @@ export default {
     checkboxId() {
       return `checkbox-${this.document.id}`
     },
-    formatedDocument () {
+    /**
+     * Deletes the "id" who should not be displayed in the document body.
+     * Also put the "_kuzzle_info" field in last position
+     */
+    formattedDocument () {
       const document = _.omit(this.document, ['id', '_kuzzle_info'])
       document._kuzzle_info = this.document._kuzzle_info
       return document

--- a/src/components/Data/Realtime/Notification.vue
+++ b/src/components/Data/Realtime/Notification.vue
@@ -82,15 +82,33 @@ export default {
       switch (this.notification.action) {
         case 'publish':
           return 'Volatile notification'
+
+        case 'mWrite':
+        case 'mCreate':
+        case 'mCreateOrReplace':
+          return `New documents created (${this.notificationId})`
+        case 'write':
         case 'create':
         case 'createOrReplace':
           return `New document created (${this.notificationId})`
+
+        case 'mReplace':
+          return `Documents replaced (${this.notificationId})`
         case 'replace':
           return `Document replaced (${this.notificationId})`
+
+        case 'updateByQuery':
+        case 'mUpdate':
+          return `Documents updated (${this.notificationId})`
         case 'update':
           return `Document updated (${this.notificationId})`
+
+        case 'deleteByQuery':
+        case 'mDelete':
+          return `Documents deleted (${this.notificationId})`
         case 'delete':
           return `Document deleted (${this.notificationId})`
+
         case 'subscribe':
           return 'A new user is listening to this room'
 

--- a/src/services/kuzzleWrapper.ts
+++ b/src/services/kuzzleWrapper.ts
@@ -76,44 +76,11 @@ class Content {
   }
 }
 
-/**
- * Constructor only used for displaying the constructor name in the list
- * JSON formatter (http://azimi.me/json-formatter-js/) check the constructor in order
- * to display the name https://github.com/mohsen1/json-formatter-js/blob/master/src/helpers.ts#L28
- */
-class Meta {
-  constructor(_kuzzle_info) {
-    if (!_kuzzle_info) {
-      return
-    }
-    this['author'] =
-      _kuzzle_info.author === '-1' ? 'Anonymous' : _kuzzle_info.author
-
-    this['updater'] =
-      _kuzzle_info.updater === '-1' ? 'Anonymous' : _kuzzle_info.updater
-
-    if (_kuzzle_info.createdAt) {
-      this['createdAt'] = `${moment(_kuzzle_info.createdAt).format(
-        'YYYY-MM-DD HH:mm:ss'
-      )} (${_kuzzle_info.createdAt})`
-    }
-    if (_kuzzle_info.updatedAt) {
-      this['updatedAt'] = `${moment(_kuzzle_info.updatedAt).format(
-        'YYYY-MM-DD HH:mm:ss'
-      )} (${_kuzzle_info.updatedAt})`
-    }
-  }
-}
-
 const formatMeta = _kuzzle_info => ({
   author: _kuzzle_info.author === '-1' ? 'Anonymous' : _kuzzle_info.author,
   updater: _kuzzle_info.updater === '-1' ? 'Anonymous' : _kuzzle_info.updater,
-  createdAt: _kuzzle_info.createdAt
-    ? `${new Date(_kuzzle_info.createdAt)} (${_kuzzle_info.createdAt})`
-    : undefined,
+  createdAt: _kuzzle_info.createdAt,
   updatedAt: _kuzzle_info.updatedAt
-    ? `${new Date(_kuzzle_info.updatedAt)} (${_kuzzle_info.updatedAt})`
-    : undefined
 })
 
 /**

--- a/src/services/kuzzleWrapper.ts
+++ b/src/services/kuzzleWrapper.ts
@@ -60,8 +60,8 @@ let getValueAdditionalAttribute = (content, attributePath) => {
 }
 
 const formatMeta = _kuzzle_info => ({
-  author: _kuzzle_info.author === '-1' ? 'Anonymous' : _kuzzle_info.author,
-  updater: _kuzzle_info.updater === '-1' ? 'Anonymous' : _kuzzle_info.updater,
+  author: _kuzzle_info.author === '-1' ? 'Anonymous (-1)' : _kuzzle_info.author,
+  updater: _kuzzle_info.updater === '-1' ? 'Anonymous (-1)' : _kuzzle_info.updater,
   createdAt: _kuzzle_info.createdAt,
   updatedAt: _kuzzle_info.updatedAt
 })

--- a/src/services/kuzzleWrapper.ts
+++ b/src/services/kuzzleWrapper.ts
@@ -1,9 +1,7 @@
 import { WebSocket } from 'kuzzle-sdk/dist/kuzzle'
 import Promise from 'bluebird'
 import Vue from 'vue'
-import sortJson from 'sort-json'
 import { omit } from 'lodash'
-import moment from 'moment'
 
 export const waitForConnected = (timeout = 1000) => {
   if (Vue.prototype.$kuzzle.protocol.state !== 'connected') {
@@ -61,62 +59,12 @@ let getValueAdditionalAttribute = (content, attributePath) => {
   return content[attribute]
 }
 
-/**
- * Constructor only used for displaying the constructor name in the list
- * JSON formatter (http://azimi.me/json-formatter-js/) check the constructor in order
- * to display the name https://github.com/mohsen1/json-formatter-js/blob/master/src/helpers.ts#L28
- */
-class Content {
-  constructor(content) {
-    Object.keys(content).forEach(key => {
-      if (key !== '_kuzzle_info') {
-        this[key] = content[key]
-      }
-    })
-  }
-}
-
 const formatMeta = _kuzzle_info => ({
   author: _kuzzle_info.author === '-1' ? 'Anonymous' : _kuzzle_info.author,
   updater: _kuzzle_info.updater === '-1' ? 'Anonymous' : _kuzzle_info.updater,
   createdAt: _kuzzle_info.createdAt,
   updatedAt: _kuzzle_info.updatedAt
 })
-
-/**
- * Constructor only used for displaying the constructor name in the list
- * JSON formatter (http://azimi.me/json-formatter-js/) check the constructor in order
- * to display the name https://github.com/mohsen1/json-formatter-js/blob/master/src/helpers.ts#L28
- */
-class Credentials {
-  constructor(credentials) {
-    Object.keys(credentials).forEach(key => {
-      this[key] = credentials[key]
-    })
-  }
-}
-
-/**
- * Constructor only used for displaying the constructor name in the list
- * JSON formatter (http://azimi.me/json-formatter-js/) check the constructor in order
- * to display the name https://github.com/mohsen1/json-formatter-js/blob/master/src/helpers.ts#L28
- */
-class Aggregations {
-  constructor(aggregations) {
-    Object.keys(aggregations).forEach(key => {
-      this[key] = aggregations[key]
-    })
-  }
-}
-
-interface IKuzzleDocument {
-  content: Content
-  id: string
-  meta: Meta
-  credentials: Credentials
-  aggregations: Aggregations
-  additionalAttribute: any
-}
 
 export const performSearchDocuments = async (
   collection,


### PR DESCRIPTION
## What does this PR do ?

Fix #679 

Display `_kuzzle_info` field at the end and remove the `id` field.

Also format dates from `_kuzzle_info` like other date fields.

**Before**
![image](https://user-images.githubusercontent.com/4447392/80938654-421ff900-8dda-11ea-8655-5c942e994403.png)

**After**
![image](https://user-images.githubusercontent.com/4447392/80938640-36343700-8dda-11ea-8f02-ef21fb71ecc9.png)

## Other changes

 - add missing notification types