### PR TITLE
Improves the style of the left menu for the "securities" pages.

### DIFF
--- a/src/components/Data/Leftnav/IndexBranch.vue
+++ b/src/components/Data/Leftnav/IndexBranch.vue
@@ -16,7 +16,7 @@
       :to="{ name: 'Collections', params: { index: indexName } }"
     >
       <i class="fa fa-database" aria-hidden="true" />
-      <span v-html="highlight(truncateName(indexName, 12), filter)" /> ({{
+      <span v-html="highlight(truncateName(indexName, 16), filter)" /> ({{
         collectionCount
       }})
     </router-link>
@@ -40,7 +40,7 @@
             aria-hidden="true"
             title="Persisted collection"
           />
-          <span v-html="highlight(truncateName(collectionName, 15), filter)" />
+          <span v-html="highlight(truncateName(collectionName, 20), filter)" />
         </router-link>
       </div>
 

--- a/src/components/Security/Layout.vue
+++ b/src/components/Security/Layout.vue
@@ -12,8 +12,8 @@
           "
         >
           <b-row no-gutters>
-            <b-col cols="2" class="text-center">
-              <i class="fa fa-user fa-lg align-bottom" aria-hidden="true" />
+            <b-col cols="2">
+              <i class="fa fa-user fa-lg align-middle" aria-hidden="true" />
             </b-col>
             <b-col cols="10" class="sideEntry pl-2 pt-1">
               Users
@@ -30,8 +30,8 @@
           "
         >
           <b-row no-gutters>
-            <b-col cols="2" class="text-center">
-              <i class="fa fa-users fa-lg align-bottom" aria-hidden="true" />
+            <b-col cols="2">
+              <i class="fa fa-id-badge fa-lg align-middle" aria-hidden="true" />
             </b-col>
             <b-col cols="10" class="sideEntry pl-2 pt-1">
               Profiles
@@ -48,9 +48,9 @@
           "
         >
           <b-row no-gutters>
-            <b-col cols="2" class="text-center">
+            <b-col cols="2">
               <i
-                class="fa fa-unlock-alt fa-lg align-bottom"
+                class="fa fa-unlock-alt fa-lg align-middle"
                 aria-hidden="true"
               />
             </b-col>
@@ -75,10 +75,6 @@
 .inactiveItemClass {
   font-weight: 100;
   opacity: 0.6;
-}
-
-.sideEntry {
-  font-size: 18px;
 }
 
 .SecurityLayout {


### PR DESCRIPTION
## What does this PR do ?
* better vertical / horizontal alignements
* change "profiles" icon
* remove too large font-size on menu entries

### Other changes
* fix #667 : increase in the number of characters displayed for index and collection names in the left menu


### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/3192870/81052006-044acf80-8ec3-11ea-9985-a5ee6adac3bb.png)

![image](https://user-images.githubusercontent.com/3192870/81052049-16c50900-8ec3-11ea-90c5-bf7c35e94ee9.png)
