### PR TITLE
Display reset button with the filter set warning

### DIFF
--- a/src/components/Common/Filters/QuickFilter.vue
+++ b/src/components/Common/Filters/QuickFilter.vue
@@ -61,7 +61,7 @@
       <div class="align-middle pt-2">
         Warning: a filter has been set, some documents might be hidden.
       </div>
-      <div>
+      <b-row>
         <b-button
           class="align-middle d-inline ml-3 font-weight-bold"
           data-cy="QuickFilter-displayActiveFilters"
@@ -69,7 +69,15 @@
           @click.prevent="displayAdvancedFilters"
           >Display the advanced filters</b-button
         >
-      </div>
+        <b-button
+          class="align-right d-inline ml-3 font-weight-bold"
+          data-cy="QuickFilter-resetBtn"
+          variant="outline-secondary"
+          @click="resetSearch"
+        >
+          Reset
+        </b-button>
+      </b-row>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## What does this PR do ?

When we display the warning about some filter has been set, IMHO it's convenient to also directly display the reset button to clear the filters.

Most of the time I see the warning so I remember that I have to clear the filter to see my documents collection but the button is 2 clicks away

![image](https://user-images.githubusercontent.com/4447392/81244851-c5785f00-9013-11ea-9d82-53a5a7f21dfd.png)
