### PR TITLE
Add keyboard navigation through indexes and collections

### DIFF
--- a/src/components/Common/AutoFocusInput.vue
+++ b/src/components/Common/AutoFocusInput.vue
@@ -19,6 +19,10 @@ export default {
       type: String,
       default: ''
     },
+    activated: {
+      type: Boolean,
+      default: true
+    }
   },
   computed: {
     refName() {
@@ -72,9 +76,17 @@ export default {
     }
   },
   mounted () {
+    if (! this.activated) {
+      return
+    }
+
     this.listenKeypress()
   },
   beforeDestroy() {
+    if (! this.activated) {
+      return
+    }
+
     this.stopListenKeypress()
   }
 

--- a/src/components/Common/AutoFocusInput.vue
+++ b/src/components/Common/AutoFocusInput.vue
@@ -34,11 +34,9 @@ export default {
   },
   methods: {
     looseFocus() {
-      console.log('loose foc')
       this.isFocus = false
     },
     listenKeypress () {
-      console.log('listen')
       document.onkeypress = keyEvent => {
         if (this.isFocus) {
           if (keyEvent.code === 'Enter') {
@@ -54,7 +52,6 @@ export default {
       }
     },
     stopListenKeypress () {
-      console.log('stop')
       document.onkeypress = null
     }
   },

--- a/src/components/Common/AutoFocusInput.vue
+++ b/src/components/Common/AutoFocusInput.vue
@@ -91,7 +91,6 @@ export default {
       document.onkeypress = null
     }
   },
-  //Cannot mount AutoFocusInput at: KuzzleAdminConsole > ConnectionAwareContainer > Home > DataLayout > DocumentsPage > Filters > QuickFilter > AutoFocusInput. An AutoFocusInput is already mounted at: KuzzleAdminConsole > ConnectionAwareContainer > Home > DataLayout > DocumentsPage > AutoFocusInput.
   mounted() {
     if (componentParents.length !== 0) {
       throw new Error(`Cannot mount AutoFocusInput at: ${getParents(this).join(' > ')}. \nAn AutoFocusInput is already mounted at: ${componentParents.join(' > ')}.`)

--- a/src/components/Common/AutoFocusInput.vue
+++ b/src/components/Common/AutoFocusInput.vue
@@ -15,6 +15,10 @@ export default {
       type: String,
       required: true
     },
+    initialValue: {
+      type: String,
+      default: ''
+    },
   },
   computed: {
     refName() {
@@ -28,7 +32,7 @@ export default {
   },
   data () {
     return {
-      value: '',
+      value: this.initialValue,
       isFocus: false
     }
   },
@@ -49,6 +53,18 @@ export default {
         this.isFocus = true;
         this.value = ''
         this.$refs[this.refName].focus()
+
+        // Firefox does not follow the key event to the input but Chrome does
+        // so after the event has finished his propagation, we check the input
+        // value and on Firefox it will be empty so we put the first letter inside
+        // Using preventDefault() to manually input the first letter and prevent
+        // to have double input on Chrome doesn't work well because then the cursor
+        // is at the wrong place
+        setTimeout(() => {
+          if (this.value === '') {
+            this.value = keyEvent.key
+          }
+        }, 1)
       }
     },
     stopListenKeypress () {

--- a/src/components/Common/AutoFocusInput.vue
+++ b/src/components/Common/AutoFocusInput.vue
@@ -3,8 +3,7 @@
     :ref="refName"
     v-model="value"
     v-bind="$attrs"
-    @blur="looseFocus"
-    data-auto-focus="true"
+    data-auto-focus-input="true"
   />
 </template>
 
@@ -24,7 +23,6 @@ export default {
   data() {
     return {
       value: this.initialValue,
-      isFocus: false
     }
   },
   computed: {
@@ -33,27 +31,27 @@ export default {
     }
   },
   methods: {
-    // AutoFocusInput is only activated when user is not using another input
-    shouldAcquireFocus() {
+    // AutoFocusInput should not handle keypress when user is using another input
+    shouldHandleKeypress() {
       const tagType = document.activeElement.tagName
 
       // If we are currently selecting another input
-      if (tagType === 'INPUT' && !document.activeElement.dataset.autoFocus) {
+      if (tagType === 'INPUT' && !document.activeElement.dataset.autoFocusInput) {
         return false
       }
 
       return true
     },
-    looseFocus() {
-      this.isFocus = false
+    isFocus() {
+      return this.$refs[this.refName].$refs.input === document.activeElement
     },
     listenKeypress() {
       document.onkeypress = keyEvent => {
-        if (!this.shouldAcquireFocus()) {
+        if (!this.shouldHandleKeypress()) {
           return
         }
 
-        if (this.isFocus) {
+        if (this.isFocus()) {
           if (keyEvent.code === 'Enter') {
             this.$emit('submit')
           }
@@ -61,7 +59,6 @@ export default {
           return
         }
 
-        this.isFocus = true
         this.$refs[this.refName].focus()
 
         // Firefox does not follow the key event to the input but Chrome does

--- a/src/components/Common/AutoFocusInput.vue
+++ b/src/components/Common/AutoFocusInput.vue
@@ -4,6 +4,7 @@
     v-model="value"
     v-bind="$attrs"
     @blur="looseFocus"
+    data-auto-focus="true"
   />
 </template>
 
@@ -18,10 +19,6 @@ export default {
     initialValue: {
       type: String,
       default: ''
-    },
-    activated: {
-      type: Boolean,
-      default: true
     }
   },
   computed: {
@@ -41,11 +38,26 @@ export default {
     }
   },
   methods: {
+    // AutoFocusInput is only activated
+    enable () {
+      const tagType = document.activeElement.tagName
+
+      // If we are currently selecting another input
+      if (tagType === 'INPUT' && !document.activeElement.dataset.autoFocus) {
+        return false
+      }
+
+      return true
+    },
     looseFocus() {
       this.isFocus = false
     },
     listenKeypress () {
       document.onkeypress = keyEvent => {
+        if (! this.enable()) {
+          return
+        }
+
         if (this.isFocus) {
           if (keyEvent.code === 'Enter') {
             this.$emit('submit')
@@ -76,17 +88,9 @@ export default {
     }
   },
   mounted () {
-    if (! this.activated) {
-      return
-    }
-
     this.listenKeypress()
   },
   beforeDestroy() {
-    if (! this.activated) {
-      return
-    }
-
     this.stopListenKeypress()
   }
 

--- a/src/components/Common/AutoFocusInput.vue
+++ b/src/components/Common/AutoFocusInput.vue
@@ -1,0 +1,69 @@
+<template>
+  <b-form-input
+    :ref="refName"
+    v-model="value"
+    v-bind="$attrs"
+    @blur="looseFocus"
+  />
+</template>
+
+<script>
+export default {
+  name: 'AutoFocusInput',
+  props: {
+    name: {
+      type: String,
+      required: true
+    },
+  },
+  computed: {
+    refName() {
+      return `auto-focus-input-${this.name}`
+    }
+  },
+  watch: {
+    value () {
+      this.$emit('input', this.value)
+    }
+  },
+  data () {
+    return {
+      value: '',
+      isFocus: false
+    }
+  },
+  methods: {
+    looseFocus() {
+      console.log('loose foc')
+      this.isFocus = false
+    },
+    listenKeypress () {
+      console.log('listen')
+      document.onkeypress = keyEvent => {
+        if (this.isFocus) {
+          if (keyEvent.code === 'Enter') {
+            this.$emit('submit')
+          }
+
+          return;
+        }
+
+        this.isFocus = true;
+        this.value = ''
+        this.$refs[this.refName].focus()
+      }
+    },
+    stopListenKeypress () {
+      console.log('stop')
+      document.onkeypress = null
+    }
+  },
+  mounted () {
+    this.listenKeypress()
+  },
+  beforeDestroy() {
+    this.stopListenKeypress()
+  }
+
+}
+</script>

--- a/src/components/Common/AutoFocusInput.vue
+++ b/src/components/Common/AutoFocusInput.vue
@@ -8,6 +8,19 @@
 </template>
 
 <script>
+
+// Keep the first mounted component parent in global to ensure developers never
+// mount two AutoFocusInput component on the same page
+let componentParents = []
+
+function getParents (component, parents = []) {
+  if (!component.$parent) {
+    return parents
+  }
+
+  return getParents(component.$parent, [component.$options.name, ...parents])
+}
+
 export default {
   name: 'AutoFocusInput',
   props: {
@@ -78,7 +91,14 @@ export default {
       document.onkeypress = null
     }
   },
+  //Cannot mount AutoFocusInput at: KuzzleAdminConsole > ConnectionAwareContainer > Home > DataLayout > DocumentsPage > Filters > QuickFilter > AutoFocusInput. An AutoFocusInput is already mounted at: KuzzleAdminConsole > ConnectionAwareContainer > Home > DataLayout > DocumentsPage > AutoFocusInput.
   mounted() {
+    if (componentParents.length !== 0) {
+      throw new Error(`Cannot mount AutoFocusInput at: ${getParents(this).join(' > ')}. \nAn AutoFocusInput is already mounted at: ${componentParents.join(' > ')}.`)
+    }
+
+    componentParents = getParents(this)
+
     this.listenKeypress()
   },
   watch: {
@@ -88,6 +108,7 @@ export default {
   },
   beforeDestroy() {
     this.stopListenKeypress()
+    componentParents = []
   }
 }
 </script>

--- a/src/components/Common/AutoFocusInput.vue
+++ b/src/components/Common/AutoFocusInput.vue
@@ -21,25 +21,20 @@ export default {
       default: ''
     }
   },
-  computed: {
-    refName() {
-      return `auto-focus-input-${this.name}`
-    }
-  },
-  watch: {
-    value () {
-      this.$emit('input', this.value)
-    }
-  },
-  data () {
+  data() {
     return {
       value: this.initialValue,
       isFocus: false
     }
   },
+  computed: {
+    refName() {
+      return `auto-focus-input-${this.name}`
+    }
+  },
   methods: {
-    // AutoFocusInput is only activated
-    enable () {
+    // AutoFocusInput is only activated when user is not using another input
+    shouldAcquireFocus() {
       const tagType = document.activeElement.tagName
 
       // If we are currently selecting another input
@@ -52,9 +47,9 @@ export default {
     looseFocus() {
       this.isFocus = false
     },
-    listenKeypress () {
+    listenKeypress() {
       document.onkeypress = keyEvent => {
-        if (! this.enable()) {
+        if (!this.shouldAcquireFocus()) {
           return
         }
 
@@ -63,10 +58,10 @@ export default {
             this.$emit('submit')
           }
 
-          return;
+          return
         }
 
-        this.isFocus = true;
+        this.isFocus = true
         this.$refs[this.refName].focus()
 
         // Firefox does not follow the key event to the input but Chrome does
@@ -82,16 +77,20 @@ export default {
         }, 1)
       }
     },
-    stopListenKeypress () {
+    stopListenKeypress() {
       document.onkeypress = null
     }
   },
-  mounted () {
+  mounted() {
     this.listenKeypress()
+  },
+  watch: {
+    value() {
+      this.$emit('input', this.value)
+    }
   },
   beforeDestroy() {
     this.stopListenKeypress()
   }
-
 }
 </script>

--- a/src/components/Common/AutoFocusInput.vue
+++ b/src/components/Common/AutoFocusInput.vue
@@ -67,7 +67,6 @@ export default {
         }
 
         this.isFocus = true;
-        this.value = ''
         this.$refs[this.refName].focus()
 
         // Firefox does not follow the key event to the input but Chrome does

--- a/src/components/Common/Breadcrumb.vue
+++ b/src/components/Common/Breadcrumb.vue
@@ -62,7 +62,7 @@
 
         <router-link
           :to="{
-            name: 'Indexes',
+            name: 'Collections',
             params: { index: $route.params.index }
           }"
         >

--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -310,9 +310,9 @@ export default {
           sorting = null
         }
 
-        this.$emit('update-filter', filters, sorting)
+        this.$emit('filter-submitted', filters, sorting)
       } else {
-        this.$emit('update-filter', filters)
+        this.$emit('filter-submitted', filters)
       }
     },
     resetSearch() {

--- a/src/components/Common/Filters/Filters.vue
+++ b/src/components/Common/Filters/Filters.vue
@@ -15,13 +15,14 @@
         <quick-filter
           v-if="!advancedFiltersVisible"
           style="flex-grow: 1"
+          v-model="quickFilter"
+          :initialValue="quickFilter"
           :action-buttons-visible="actionButtonsVisible"
           :advanced-filters-visible="advancedFiltersVisible"
           :advanced-query-label="advancedQueryLabel"
           :complex-filter-active="complexFilterActive"
           :enabled="quickFilterEnabled"
           :placeholder="quickFilterPlaceholder"
-          :search-term="quickFilter"
           :submit-button-label="submitButtonLabel"
           :submit-on-type="quickFilterSubmitOnType"
           @display-advanced-filters="
@@ -116,7 +117,7 @@
 import QuickFilter from './QuickFilter'
 import BasicFilter from './BasicFilter'
 import RawFilter from './RawFilter'
-import Vue from 'vue'
+
 import {
   NO_ACTIVE,
   ACTIVE_QUICK,
@@ -198,11 +199,17 @@ export default {
           this.currentFilter.raw !== null)
       )
     },
-    quickFilter() {
-      if (!this.currentFilter) {
-        return null
+    quickFilter: {
+      get () {
+        if (!this.currentFilter) {
+          return null
+        }
+
+        return this.currentFilter.quick
+      },
+      set (value) {
+        this.currentFilter.quick = value
       }
-      return this.currentFilter.quick
     },
     basicFilter() {
       if (!this.currentFilter) {
@@ -219,14 +226,6 @@ export default {
     sorting() {
       return this.currentFilter.sorting
     }
-  },
-  mounted() {
-    Vue.nextTick(() => {
-      window.document.addEventListener('keydown', this.handleEsc)
-    })
-  },
-  destroyed() {
-    window.document.removeEventListener('keydown', this.handleEsc)
   },
   methods: {
     onQuickFilterUpdated(term) {

--- a/src/components/Common/Filters/Filters.vue
+++ b/src/components/Common/Filters/Filters.vue
@@ -28,7 +28,7 @@
           @display-advanced-filters="
             advancedFiltersVisible = !advancedFiltersVisible
           "
-          @update-filter="onQuickFilterUpdated"
+          @filter-submitted="onQuickFilterUpdated"
           @refresh="onRefresh"
           @reset="onReset"
           @enter-pressed="onEnterPressed"
@@ -64,7 +64,7 @@
         :submit-button-label="submitButtonLabel"
         :current-filter="currentFilter"
         :refresh-ace="refreshace"
-        @update-filter="onRawFilterUpdated"
+        @filter-submitted="onRawFilterUpdated"
         @reset="onReset"
       />
       <basic-filter
@@ -77,7 +77,7 @@
         :action-buttons-visible="actionButtonsVisible"
         :sorting="sorting"
         :collection-mapping="collectionMapping"
-        @update-filter="onBasicFilterUpdated"
+        @filter-submitted="onBasicFilterUpdated"
         @reset="onReset"
       />
     </template>

--- a/src/components/Common/Filters/Filters.vue
+++ b/src/components/Common/Filters/Filters.vue
@@ -30,6 +30,7 @@
           @update-filter="onQuickFilterUpdated"
           @refresh="onRefresh"
           @reset="onReset"
+          @enter-pressed="onEnterPressed"
         />
         <template v-if="advancedFiltersVisible">
           <b-nav-item
@@ -272,6 +273,9 @@ export default {
     onFiltersUpdated(newFilters) {
       this.advancedFiltersVisible = false
       this.$emit('filters-updated', newFilters)
+    },
+    onEnterPressed () {
+      this.$emit('enter-pressed')
     }
   }
 }

--- a/src/components/Common/Filters/QuickFilter.vue
+++ b/src/components/Common/Filters/QuickFilter.vue
@@ -13,8 +13,9 @@
               data-cy="QuickFilter-input"
               debounce="300"
               :placeholder="placeholder"
+              :initialValue="this.initialValue"
               type="search"
-              v-model="inputSearchTerm"
+              v-model="value"
               @submit="inputSubmit"
             />
           </b-input-group>
@@ -83,7 +84,6 @@ export default {
     AutoFocusInput
   },
   props: {
-    searchTerm: String,
     advancedFiltersVisible: Boolean,
     advancedQueryLabel: {
       type: String,
@@ -109,16 +109,20 @@ export default {
     submitOnType: {
       type: Boolean,
       default: true
+    },
+    initialValue: {
+      type: String,
+      default: ''
     }
   },
   data() {
     return {
-      inputSearchTerm: this.searchTerm
+      value: this.initialValue
     }
   },
   methods: {
     submitSearch() {
-      this.$emit('update-filter', this.inputSearchTerm)
+      this.$emit('update-filter', this.value)
     },
     resetSearch() {
       this.$emit('reset')
@@ -131,16 +135,11 @@ export default {
     }
   },
   watch: {
-    inputSearchTerm() {
-      if (!this.submitOnType) {
-        return
-      }
-      this.submitSearch()
-    },
-    searchTerm: {
-      immediate: true,
-      handler(val) {
-        this.inputSearchTerm = val
+    value () {
+      this.$emit('input', this.value)
+
+    if (this.submitOnType) {
+        this.submitSearch()
       }
     }
   }

--- a/src/components/Common/Filters/QuickFilter.vue
+++ b/src/components/Common/Filters/QuickFilter.vue
@@ -8,15 +8,15 @@
               <i class="fa fa-search search" />
             </b-input-group-prepend>
 
-            <b-form-input
+            <auto-focus-input
+              name="quick-filter"
               data-cy="QuickFilter-input"
               debounce="300"
               :placeholder="placeholder"
               type="search"
               v-model="inputSearchTerm"
-              v-focus
-            >
-            </b-form-input>
+              @submit="inputSubmit"
+            />
           </b-input-group>
         </div>
       </b-col>
@@ -75,12 +75,12 @@
 </template>
 
 <script>
-import Focus from '../../../directives/focus.directive'
+import AutoFocusInput from '../AutoFocusInput'
 
 export default {
   name: 'QuickFilter',
-  directives: {
-    Focus
+  components: {
+    AutoFocusInput
   },
   props: {
     searchTerm: String,
@@ -125,6 +125,9 @@ export default {
     },
     displayAdvancedFilters() {
       this.$emit('display-advanced-filters')
+    },
+    inputSubmit () {
+      this.$emit('enter-pressed')
     }
   },
   watch: {

--- a/src/components/Common/Filters/QuickFilter.vue
+++ b/src/components/Common/Filters/QuickFilter.vue
@@ -122,7 +122,7 @@ export default {
   },
   methods: {
     submitSearch() {
-      this.$emit('update-filter', this.value)
+      this.$emit('filter-submitted', this.value)
     },
     resetSearch() {
       this.$emit('reset')

--- a/src/components/Common/Filters/RawFilter.vue
+++ b/src/components/Common/Filters/RawFilter.vue
@@ -109,7 +109,7 @@ export default {
     submit() {
       if (this.isFilterValid) {
         this.showError = false
-        this.$emit('update-filter', this.filterState)
+        this.$emit('filter-submitted', this.filterState)
       } else {
         this.showError = true
       }

--- a/src/components/Data/Collections/CollectionList.vue
+++ b/src/components/Data/Collections/CollectionList.vue
@@ -41,10 +41,14 @@
               <template v-slot:prepend>
                 <b-input-group-text>Filter</b-input-group-text>
               </template>
-              <b-form-input
+
+              <auto-focus-input
+                name="collection"
                 v-model="filter"
+                @submit="submitFilter"
                 :disabled="collections.length === 0"
-              ></b-form-input>
+              />
+
             </b-input-group>
           </b-col>
         </b-row>
@@ -58,6 +62,7 @@
           :items="collections"
           :fields="tableFields"
           :filter="filter"
+          @filtered="updateFilteredCollections"
         >
           <template v-slot:empty>
             <h4 class="text-secondary text-center">
@@ -219,6 +224,8 @@
 import Headline from '../../Materialize/Headline'
 import ListNotAllowed from '../../Common/ListNotAllowed'
 import MainSpinner from '../../Common/MainSpinner'
+import AutoFocusInput from '../../Common/AutoFocusInput'
+
 import {
   canDeleteIndex,
   canSearchIndex,
@@ -236,7 +243,8 @@ export default {
     DataNotFound,
     Headline,
     ListNotAllowed,
-    MainSpinner
+    MainSpinner,
+    AutoFocusInput
   },
   directives: {
     Title
@@ -249,7 +257,8 @@ export default {
       filter: '',
       collectionToDelete: '',
       deleteConfirmation: '',
-      rawStoredCollections: []
+      rawStoredCollections: [],
+      filteredCollections: []
     }
   },
   computed: {
@@ -405,6 +414,23 @@ export default {
           }
         )
       }
+    },
+    submitFilter () {
+      const collection = this.filteredCollections[0]
+
+      if (! collection) {
+        return
+      }
+
+      const route = {
+        name: collection.type === 'realtime' ? 'WatchCollection' : 'DocumentList',
+        params: { index: this.index, collection: collection.name }
+      }
+
+      this.$router.push(route)
+    },
+    updateFilteredCollections (filteredCollections) {
+      this.filteredCollections = filteredCollections
     }
   },
   mounted() {

--- a/src/components/Data/Collections/CollectionList.vue
+++ b/src/components/Data/Collections/CollectionList.vue
@@ -45,7 +45,7 @@
               <auto-focus-input
                 name="collection"
                 v-model="filter"
-                @submit="submitFilter"
+                @submit="navigateToCollection"
                 :disabled="collections.length === 0"
               />
 
@@ -415,7 +415,7 @@ export default {
         )
       }
     },
-    submitFilter () {
+    navigateToCollection () {
       const collection = this.filteredCollections[0]
 
       if (! collection) {

--- a/src/components/Data/Documents/DocumentListItem.vue
+++ b/src/components/Data/Documents/DocumentListItem.vue
@@ -147,7 +147,10 @@ export default {
     },
     editDocument() {
       if (this.canEdit) {
-        this.$emit('edit', this.document.id)
+        this.$router.push({
+          name: 'UpdateDocument',
+          params: { id: this.document.id }
+        })
       }
     }
   }

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -58,6 +58,7 @@
                   :collection-mapping="collectionMapping"
                   @filters-updated="onFiltersUpdated"
                   @reset="onFiltersUpdated"
+                  @enter-pressed="navigateToDocument"
                 />
               </template>
             </b-col>
@@ -95,7 +96,6 @@
                       @change-page-size="changePaginationSize"
                       @checkbox-click="toggleSelectDocuments"
                       @delete="onDeleteClicked"
-                      @edit="onEditDocumentClicked"
                       @refresh="onRefresh"
                       @toggle-all="onToggleAllClicked"
                     ></List>
@@ -110,7 +110,6 @@
                       :all-checked="allChecked"
                       :current-page-size="paginationSize"
                       :total-documents="totalDocuments"
-                      @edit="onEditDocumentClicked"
                       @delete="onDeleteClicked"
                       @bulk-delete="onBulkDeleteClicked"
                       @change-page-size="changePaginationSize"
@@ -366,15 +365,6 @@ export default {
       this.$router.push({ name: 'CreateDocument' })
     },
 
-    // UPDATE
-    // =========================================================================
-    onEditDocumentClicked(id) {
-      this.$router.push({
-        name: 'UpdateDocument',
-        params: { id }
-      })
-    },
-
     // DELETE
     // =========================================================================
     performDeleteDocuments,
@@ -442,6 +432,18 @@ export default {
       this.fetchDocuments()
     },
     performSearchDocuments,
+    navigateToDocument () {
+      const document = this.documents[0]
+
+      if (! document) {
+        return
+      }
+
+      this.$router.push({
+        name: 'UpdateDocument',
+        params: { id: document.id }
+      })
+    },
     async onFiltersUpdated(newFilters) {
       this.currentFilter = newFilters
       try {

--- a/src/components/Data/Documents/Views/List.vue
+++ b/src/components/Data/Documents/Views/List.vue
@@ -60,7 +60,6 @@
           :index="index"
           :is-checked="isChecked(document.id)"
           @checkbox-click="$emit('checkbox-click', $event)"
-          @edit="$emit('edit', $event)"
           @delete="$emit('delete', $event)"
         />
       </b-list-group-item>

--- a/src/components/Data/Indexes/Page.vue
+++ b/src/components/Data/Indexes/Page.vue
@@ -36,7 +36,7 @@
                 name="index"
                 v-model="filter"
                 :disabled="tableItems.length === 0"
-                @submit="submitFilter"
+                @submit="navigateToIndex"
               />
 
             </b-input-group>
@@ -211,7 +211,7 @@ export default {
       this.indexToDelete = index
       this.$bvModal.show(this.deleteIndexModalId)
     },
-    submitFilter () {
+    navigateToIndex () {
       const index = this.filteredIndexes[0]
 
       if (! index) {

--- a/src/components/Data/Indexes/Page.vue
+++ b/src/components/Data/Indexes/Page.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-container class="IndexesPage">
+  <b-container class="IndexesPage" ref="page-indexes">
     <headline>
       Indexes
       <b-button
@@ -31,10 +31,14 @@
               <template v-slot:prepend>
                 <b-input-group-text>Filter</b-input-group-text>
               </template>
-              <b-form-input
+
+              <auto-focus-input
+                name="index"
                 v-model="filter"
                 :disabled="tableItems.length === 0"
-              ></b-form-input>
+                @submit="submitFilter"
+              />
+
             </b-input-group>
           </b-col>
         </b-row>
@@ -48,6 +52,7 @@
           :items="tableItems"
           :fields="tableFields"
           :filter="filter"
+          @filtered="updateFilteredIndexes"
         >
           <template v-slot:empty>
             <h4 class="text-secondary text-center">There is no index.</h4>
@@ -123,6 +128,7 @@ import Headline from '../../Materialize/Headline'
 import CreateIndexModal from './CreateIndexModal'
 import DeleteIndexModal from './DeleteIndexModal'
 import ListNotAllowed from '../../Common/ListNotAllowed'
+import AutoFocusInput from '../../Common/AutoFocusInput'
 
 import Title from '../../../directives/title.directive'
 import {
@@ -136,7 +142,8 @@ export default {
     Headline,
     CreateIndexModal,
     DeleteIndexModal,
-    ListNotAllowed
+    ListNotAllowed,
+    AutoFocusInput
   },
   directives: {
     Title
@@ -170,7 +177,8 @@ export default {
           label: '',
           class: 'text-right align-middle'
         }
-      ]
+      ],
+      filteredIndexes: []
     }
   },
   computed: {
@@ -202,8 +210,25 @@ export default {
     openDeleteModal(index) {
       this.indexToDelete = index
       this.$bvModal.show(this.deleteIndexModalId)
+    },
+    submitFilter () {
+      const index = this.filteredIndexes[0]
+
+      if (! index) {
+        return
+      }
+
+      const route = {
+        name: 'Collections',
+        params: { index: index.indexName }
+      }
+
+      this.$router.push(route)
+    },
+    updateFilteredIndexes (filteredIndexes) {
+      this.filteredIndexes = filteredIndexes
     }
-  }
+  },
 }
 </script>
 

--- a/src/components/Materialize/Modal.vue
+++ b/src/components/Materialize/Modal.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="isOpen" :id="id" class="modal" :class="computedClasses">
+    <div v-if="isOpen" :id="id" class="modal" :class="computedClasses" data-modal="true">
       <slot name="content">
         <div class="modal-content">
           <slot />

--- a/src/components/Security/Profiles/List.vue
+++ b/src/components/Security/Profiles/List.vue
@@ -1,124 +1,122 @@
 <template>
   <div class="ProfileList">
-    <template v-if="loading">
-      <b-row class="text-center">
-        <b-col>
-          <b-spinner variant="primary" class="mt-5"></b-spinner>
-        </b-col>
-      </b-row>
-    </template>
+    <slot
+      v-if="currentFilter.basic && totalDocuments === 0"
+      name="emptySet"
+    />
     <template v-else>
-      <slot
-        v-if="currentFilter.basic && totalDocuments === 0"
-        name="emptySet"
+      <filters
+        :current-filter="currentFilter"
+        @filters-updated="onFiltersUpdated"
       />
-      <template v-else>
-        <filters
-          :current-filter="currentFilter"
-          @filters-updated="onFiltersUpdated"
-        />
-        <b-card
-          class="light-shadow mt-3"
-          :bg-variant="documents.length === 0 ? 'light' : 'default'"
-        >
-          <b-card-text class="p-0">
-            <div v-show="!documents.length" class="row valign-center empty-set">
-              <b-row align-h="center" class="valign-center empty-set">
-                <b-col cols="2" class="text-center">
+      <b-card
+        class="light-shadow mt-3"
+        :bg-variant="documents.length === 0 ? 'light' : 'default'"
+      >
+        <template v-if="loading">
+          <b-row class="text-center">
+            <b-col>
+              <b-spinner variant="primary" class="mt-5"></b-spinner>
+            </b-col>
+          </b-row>
+        </template>
+        <b-card-text class="p-0">
+          <div v-show="!documents.length" class="row valign-center empty-set">
+            <b-row align-h="center" class="valign-center empty-set">
+              <b-col cols="2" class="text-center">
+                <i
+                  class="fa fa-5x fa-search text-secondary mt-3"
+                  aria-hidden="true"
+                />
+              </b-col>
+              <b-col md="6">
+                <h3 class="text-secondary font-weight-bold">
+                  There is no result matching your query. Please try with
+                  another filter.
+                </h3>
+                <p>
+                  <em
+                    >Learn more about filtering syntax on
+                    <a
+                      href="https://docs.kuzzle.io/guide/1/elasticsearch/"
+                      target="_blank"
+                      >Kuzzle Elasticsearch Cookbook</a
+                    ></em
+                  >
+                </p>
+              </b-col>
+            </b-row>
+          </div>
+          <div v-if="documents.length">
+            <b-row no-gutters class="mb-2">
+              <b-col cols="8">
+                <b-button
+                  variant="outline-dark"
+                  class="mr-2"
+                  data-cy="ProfileList-toggleAllBtn"
+                  @click="toggleAll"
+                >
                   <i
-                    class="fa fa-5x fa-search text-secondary mt-3"
-                    aria-hidden="true"
+                    :class="
+                      `far ${
+                        allChecked ? 'fa-check-square' : 'fa-square'
+                      } left`
+                    "
                   />
-                </b-col>
-                <b-col md="6">
-                  <h3 class="text-secondary font-weight-bold">
-                    There is no result matching your query. Please try with
-                    another filter.
-                  </h3>
-                  <p>
-                    <em
-                      >Learn more about filtering syntax on
-                      <a
-                        href="https://docs.kuzzle.io/guide/1/elasticsearch/"
-                        target="_blank"
-                        >Kuzzle Elasticsearch Cookbook</a
-                      ></em
-                    >
-                  </p>
-                </b-col>
-              </b-row>
-            </div>
-            <div v-if="documents.length">
-              <b-row no-gutters class="mb-2">
-                <b-col cols="8">
-                  <b-button
-                    variant="outline-dark"
-                    class="mr-2"
-                    data-cy="ProfileList-toggleAllBtn"
-                    @click="toggleAll"
-                  >
-                    <i
-                      :class="
-                        `far ${
-                          allChecked ? 'fa-check-square' : 'fa-square'
-                        } left`
-                      "
-                    />
-                    Toggle all
-                  </b-button>
+                  Toggle all
+                </b-button>
 
-                  <b-button
-                    variant="outline-danger"
-                    class="mr-2"
-                    data-cy="ProfileList-bulkDeleteBtn"
-                    :disabled="!displayBulkDelete"
-                    @click="deleteBulk"
-                  >
-                    <i class="fa fa-minus-circle left" />
-                    Delete selected
-                  </b-button>
-                </b-col>
-              </b-row>
-            </div>
+                <b-button
+                  variant="outline-danger"
+                  class="mr-2"
+                  data-cy="ProfileList-bulkDeleteBtn"
+                  :disabled="!displayBulkDelete"
+                  @click="deleteBulk"
+                >
+                  <i class="fa fa-minus-circle left" />
+                  Delete selected
+                </b-button>
+              </b-col>
+            </b-row>
+          </div>
 
-            <div
-              v-show="documents.length"
-              class="row CrudlDocument-collection"
-              data-cy="ProfileList-items"
-            >
-              <div class="col s12">
-                <b-list-group class="w-100">
-                  <b-list-group-item
-                    v-for="document in documents"
-                    class="p-2"
-                    data-cy="ProfileList-item"
-                    :key="document._id"
-                  >
-                    <ProfileItem
-                      :document="document"
-                      :is-checked="isChecked(document._id)"
-                      :index="index"
-                      :collection="collection"
-                      @checkbox-click="toggleSelectDocuments"
-                      @edit="editProfile(document._id)"
-                      @delete="deleteProfile"
-                    />
-                  </b-list-group-item>
-                </b-list-group>
-              </div>
+          <div
+            v-show="documents.length"
+            class="row CrudlDocument-collection"
+            data-cy="ProfileList-items"
+          >
+            <div class="col s12">
+              <b-list-group class="w-100">
+                <b-list-group-item
+                  v-for="document in documents"
+                  class="p-2"
+                  data-cy="ProfileList-item"
+                  :key="document._id"
+                >
+                  <ProfileItem
+                    :document="document"
+                    :is-checked="isChecked(document._id)"
+                    :index="index"
+                    :collection="collection"
+                    @checkbox-click="toggleSelectDocuments"
+                    @edit="editProfile(document._id)"
+                    @delete="deleteProfile"
+                  />
+                </b-list-group-item>
+              </b-list-group>
             </div>
-          </b-card-text>
-        </b-card>
-        <b-row align-h="center">
-          <b-pagination
-            class="m-2 mt-4"
-            data-cy="ProfileManagement-pagination"
-            v-model="currentPage"
-            :total-rows="totalDocuments"
-            :per-page="paginationSize"
-          ></b-pagination>
-        </b-row>
-      </template>
+          </div>
+        </b-card-text>
+      </b-card>
+      <b-row align-h="center">
+        <b-pagination
+          class="m-2 mt-4"
+          data-cy="ProfileManagement-pagination"
+          v-model="currentPage"
+          :total-rows="totalDocuments"
+          :per-page="paginationSize"
+        ></b-pagination>
+      </b-row>
     </template>
     <delete-modal
       id="modal-delete-profiles"

--- a/src/components/Security/Roles/List.vue
+++ b/src/components/Security/Roles/List.vue
@@ -1,99 +1,98 @@
 <template>
   <div class="RoleList">
-    <template v-if="loading">
-      <b-row class="text-center">
-        <b-col>
-          <b-spinner variant="primary" class="mt-5"></b-spinner>
-        </b-col>
-      </b-row>
-    </template>
+    <slot
+      v-if="!currentFilter.basic && totalDocuments === 0"
+      name="emptySet"
+    />
     <template v-else>
-      <slot
-        v-if="!currentFilter.basic && totalDocuments === 0"
-        name="emptySet"
+      <filters
+        class="mb-3"
+        :current-filter="currentFilter.basic"
+        @filters-updated="onFiltersUpdated"
+        @reset="onFiltersUpdated"
       />
-      <template v-else>
-        <filters
-          class="mb-3"
-          :current-filter="currentFilter.basic"
-          @filters-updated="onFiltersUpdated"
-          @reset="onFiltersUpdated"
-        />
-        <b-card
-          class="light-shadow"
-          :bg-variant="documents.length === 0 ? 'light' : 'default'"
-        >
-          <b-card-text class="p-0">
-            <div v-show="!documents.length" class="row valign-center empty-set">
-              <b-row align-h="center" class="valign-center empty-set">
-                <b-col cols="2" class="text-center">
-                  <i
-                    class="fa fa-5x fa-search text-secondary mt-3"
-                    aria-hidden="true"
-                  />
-                </b-col>
-                <b-col md="6">
-                  <h3 class="text-secondary font-weight-bold">
-                    There is no result matching your query. Please try with
-                    another filter.
-                  </h3>
-                  <p>
-                    <em
-                      >Learn more about filtering syntax on
-                      <a
-                        href="https://docs.kuzzle.io/core/2/guides/cookbooks/elasticsearch/basic-queries/"
-                        target="_blank"
-                        >Kuzzle Elasticsearch Cookbook</a
-                      ></em
-                    >
-                  </p>
-                </b-col>
-              </b-row>
-            </div>
-            <div v-if="documents.length">
-              <b-row no-gutters class="mb-2">
-                <b-col cols="8">
-                  <b-button
-                    variant="outline-danger"
-                    class="mr-2"
-                    data-cy="UserList-bulkDeleteBtn"
-                    :disabled="!displayBulkDelete"
-                    @click="deleteBulk"
-                  >
-                    <i class="fa fa-minus-circle left" />
-                    Delete selected
-                  </b-button>
-                </b-col>
-              </b-row>
-            </div>
-            <b-list-group class="RoleList-list collection">
-              <b-list-group-item
-                v-for="document in documents"
-                data-cy="RoleList-list"
-                :key="document.id"
-                class="p-2"
-              >
-                <RoleItem
-                  :document="document"
-                  :is-checked="isChecked(document.id)"
-                  @checkbox-click="toggleSelectDocuments"
-                  @common-list::edit-document="editDocument"
-                  @delete-document="deleteRole"
+      <b-card
+        class="light-shadow"
+        :bg-variant="documents.length === 0 ? 'light' : 'default'"
+      >
+        <template v-if="loading">
+          <b-row class="text-center">
+            <b-col>
+              <b-spinner variant="primary" class="mt-5"></b-spinner>
+            </b-col>
+          </b-row>
+        </template>
+
+        <b-card-text class="p-0">
+          <div v-show="!documents.length" class="row valign-center empty-set">
+            <b-row align-h="center" class="valign-center empty-set">
+              <b-col cols="2" class="text-center">
+                <i
+                  class="fa fa-5x fa-search text-secondary mt-3"
+                  aria-hidden="true"
                 />
-              </b-list-group-item>
-            </b-list-group>
-          </b-card-text>
-        </b-card>
-        <b-row align-h="center">
-          <b-pagination
-            class="m-2 mt-4"
-            data-cy="RolesManagement-pagination"
-            v-model="currentPage"
-            :total-rows="totalDocuments"
-            :per-page="paginationSize"
-          ></b-pagination>
-        </b-row>
-      </template>
+              </b-col>
+              <b-col md="6">
+                <h3 class="text-secondary font-weight-bold">
+                  There is no result matching your query. Please try with
+                  another filter.
+                </h3>
+                <p>
+                  <em
+                    >Learn more about filtering syntax on
+                    <a
+                      href="https://docs.kuzzle.io/core/2/guides/cookbooks/elasticsearch/basic-queries/"
+                      target="_blank"
+                      >Kuzzle Elasticsearch Cookbook</a
+                    ></em
+                  >
+                </p>
+              </b-col>
+            </b-row>
+          </div>
+          <div v-if="documents.length">
+            <b-row no-gutters class="mb-2">
+              <b-col cols="8">
+                <b-button
+                  variant="outline-danger"
+                  class="mr-2"
+                  data-cy="UserList-bulkDeleteBtn"
+                  :disabled="!displayBulkDelete"
+                  @click="deleteBulk"
+                >
+                  <i class="fa fa-minus-circle left" />
+                  Delete selected
+                </b-button>
+              </b-col>
+            </b-row>
+          </div>
+          <b-list-group class="RoleList-list collection">
+            <b-list-group-item
+              v-for="document in documents"
+              data-cy="RoleList-list"
+              :key="document.id"
+              class="p-2"
+            >
+              <RoleItem
+                :document="document"
+                :is-checked="isChecked(document.id)"
+                @checkbox-click="toggleSelectDocuments"
+                @common-list::edit-document="editDocument"
+                @delete-document="deleteRole"
+              />
+            </b-list-group-item>
+          </b-list-group>
+        </b-card-text>
+      </b-card>
+      <b-row align-h="center">
+        <b-pagination
+          class="m-2 mt-4"
+          data-cy="RolesManagement-pagination"
+          v-model="currentPage"
+          :total-rows="totalDocuments"
+          :per-page="paginationSize"
+        ></b-pagination>
+      </b-row>
     </template>
     <delete-modal
       id="modal-delete-roles"

--- a/src/components/Security/Users/List.vue
+++ b/src/components/Security/Users/List.vue
@@ -1,5 +1,18 @@
 <template>
   <div class="UserList">
+    <slot v-if="isCollectionEmpty" name="emptySet" />
+    <b-row class="justify-content-md-center" no-gutters>
+      <b-col cols="12">
+        <filters
+          class="mb-3"
+          :available-operands="searchFilterOperands"
+          :current-filter="currentFilter"
+          :collection-mapping="collectionMapping"
+          @filters-updated="onFiltersUpdated"
+          @reset="onFiltersUpdated"
+        />
+      </b-col>
+    </b-row>
     <template v-if="fetchingUsers">
       <b-row class="text-center">
         <b-col>
@@ -7,124 +20,109 @@
         </b-col>
       </b-row>
     </template>
-    <template v-else>
-      <slot v-if="isCollectionEmpty" name="emptySet" />
-      <template v-else>
-        <b-row class="justify-content-md-center" no-gutters>
-          <b-col cols="12">
-            <filters
-              class="mb-3"
-              :available-operands="searchFilterOperands"
-              :current-filter="currentFilter"
-              :collection-mapping="collectionMapping"
-              @filters-updated="onFiltersUpdated"
-              @reset="onFiltersUpdated"
-            />
-          </b-col>
-        </b-row>
-        <b-card
-          class="light-shadow"
-          :bg-variant="documents.length === 0 ? 'light' : 'default'"
+    <b-card
+      v-else
+      class="light-shadow"
+      :bg-variant="documents.length === 0 ? 'light' : 'default'"
+    >
+      <b-card-text class="p-0">
+        <div v-show="!documents.length" class="row valign-center empty-set">
+          <b-row align-h="center" class="valign-center empty-set">
+            <b-col cols="2" class="text-center">
+              <i
+                class="fa fa-5x fa-search text-secondary mt-3"
+                aria-hidden="true"
+              />
+            </b-col>
+            <b-col md="6">
+              <h3 class="text-secondary font-weight-bold">
+                There is no result matching your query. Please try with
+                another filter.
+              </h3>
+              <p>
+                <em
+                  >Learn more about filtering syntax on
+                  <a
+                    href="https://docs.kuzzle.io/core/2/guides/cookbooks/elasticsearch/basic-queries/"
+                    target="_blank"
+                    >Kuzzle Elasticsearch Cookbook</a
+                  ></em
+                >
+              </p>
+            </b-col>
+          </b-row>
+        </div>
+
+        <div v-if="documents.length">
+          <b-row no-gutters class="mb-2">
+            <b-col cols="8">
+              <b-button
+                variant="outline-dark"
+                class="mr-2"
+                data-cy="UserList-toggleAllBtn"
+                @click="toggleAll"
+              >
+                <i
+                  :class="
+                    `far ${
+                      allChecked ? 'fa-check-square' : 'fa-square'
+                    } left`
+                  "
+                />
+                Toggle all
+              </b-button>
+
+              <b-button
+                variant="outline-danger"
+                class="mr-2"
+                data-cy="UserList-bulkDeleteBtn"
+                :disabled="!displayBulkDelete"
+                @click="deleteBulk"
+              >
+                <i class="fa fa-minus-circle left" />
+                Delete selected
+              </b-button>
+            </b-col>
+          </b-row>
+        </div>
+
+        <div
+          v-show="documents.length"
+          class="row CrudlDocument-collection"
+          data-cy="UserList-items"
         >
-          <b-card-text class="p-0">
-            <div v-show="!documents.length" class="row valign-center empty-set">
-              <b-row align-h="center" class="valign-center empty-set">
-                <b-col cols="2" class="text-center">
-                  <i
-                    class="fa fa-5x fa-search text-secondary mt-3"
-                    aria-hidden="true"
-                  />
-                </b-col>
-                <b-col md="6">
-                  <h3 class="text-secondary font-weight-bold">
-                    There is no result matching your query. Please try with
-                    another filter.
-                  </h3>
-                  <p>
-                    <em
-                      >Learn more about filtering syntax on
-                      <a
-                        href="https://docs.kuzzle.io/core/2/guides/cookbooks/elasticsearch/basic-queries/"
-                        target="_blank"
-                        >Kuzzle Elasticsearch Cookbook</a
-                      ></em
-                    >
-                  </p>
-                </b-col>
-              </b-row>
-            </div>
-            <div v-if="documents.length">
-              <b-row no-gutters class="mb-2">
-                <b-col cols="8">
-                  <b-button
-                    variant="outline-dark"
-                    class="mr-2"
-                    data-cy="UserList-toggleAllBtn"
-                    @click="toggleAll"
-                  >
-                    <i
-                      :class="
-                        `far ${
-                          allChecked ? 'fa-check-square' : 'fa-square'
-                        } left`
-                      "
-                    />
-                    Toggle all
-                  </b-button>
-
-                  <b-button
-                    variant="outline-danger"
-                    class="mr-2"
-                    data-cy="UserList-bulkDeleteBtn"
-                    :disabled="!displayBulkDelete"
-                    @click="deleteBulk"
-                  >
-                    <i class="fa fa-minus-circle left" />
-                    Delete selected
-                  </b-button>
-                </b-col>
-              </b-row>
-            </div>
-
-            <div
-              v-show="documents.length"
-              class="row CrudlDocument-collection"
-              data-cy="UserList-items"
-            >
-              <div class="col s12">
-                <b-list-group class="w-100">
-                  <b-list-group-item
-                    v-for="document in documents"
-                    class="p-2"
-                    data-cy="UserList-item"
-                    :key="document.id"
-                  >
-                    <UserItem
-                      :document="document"
-                      :is-checked="isChecked(document.id)"
-                      :index="index"
-                      :collection="collection"
-                      @checkbox-click="toggleSelectDocuments"
-                      @edit="editUser"
-                      @delete="deleteUser"
-                    />
-                  </b-list-group-item>
-                </b-list-group>
-              </div>
-            </div>
-          </b-card-text>
-        </b-card>
-        <b-row align-h="center">
-          <b-pagination
-            class="m-2 mt-4"
-            data-cy="UserManagement-pagination"
-            v-model="currentPage"
-            :total-rows="totalDocuments"
-            :per-page="paginationSize"
-          ></b-pagination>
-        </b-row>
-      </template>
-    </template>
+          <div class="col s12">
+            <b-list-group class="w-100">
+              <b-list-group-item
+                v-for="document in documents"
+                class="p-2"
+                data-cy="UserList-item"
+                :key="document.id"
+              >
+                <UserItem
+                  :document="document"
+                  :is-checked="isChecked(document.id)"
+                  :index="index"
+                  :collection="collection"
+                  @checkbox-click="toggleSelectDocuments"
+                  @edit="editUser"
+                  @delete="deleteUser"
+                />
+              </b-list-group-item>
+            </b-list-group>
+          </div>
+        </div>
+      </b-card-text>
+    </b-card>
+    <b-row align-h="center">
+      <b-pagination
+        class="m-2 mt-4"
+        data-cy="UserManagement-pagination"
+        v-model="currentPage"
+        :total-rows="totalDocuments"
+        :per-page="paginationSize"
+      ></b-pagination>
+    </b-row>
     <delete-modal
       id="modal-delete-users"
       :candidates-for-deletion="candidatesForDeletion"

--- a/test/e2e/cypress/integration/collections.spec.js
+++ b/test/e2e/cypress/integration/collections.spec.js
@@ -102,4 +102,18 @@ describe('Collection management', function() {
     cy.get('[data-cy="DeleteCollectionPrompt-OK"]').click()
     cy.should('not.contain', collectionName)
   })
+
+  it('Should be able to autofocus collection search', () => {
+    cy.request('PUT', `${kuzzleUrl}/${indexName}/${collectionName}`)
+    cy.request('PUT', `${kuzzleUrl}/${indexName}/foobar`)
+
+    cy.waitOverlay()
+
+    cy.visit(`/#/data/${indexName}/`)
+    cy.wait(500)
+
+    cy.get('body').type('f{enter}')
+
+    cy.contains('This collection is empty')
+  })
 })

--- a/test/e2e/cypress/integration/collections.spec.js
+++ b/test/e2e/cypress/integration/collections.spec.js
@@ -114,6 +114,8 @@ describe('Collection management', function() {
 
     cy.get('body').type('f{enter}')
 
+    cy.url().should('contain', 'foobar')
+    cy.contains('foobar')
     cy.contains('This collection is empty')
   })
 })

--- a/test/e2e/cypress/integration/docs.spec.js
+++ b/test/e2e/cypress/integration/docs.spec.js
@@ -126,6 +126,17 @@ describe('Document List', function() {
     cy.get('[data-cy="ColumnViewHead--Value2"]').should('exist')
   })
 
+  it('should be able to autofocus document quick-filter', () => {
+    cy.waitOverlay()
+
+    cy.visit(`/#/data/${indexName}/${collectionName}`)
+    cy.wait(500)
+
+    cy.get('body').type('L{enter}')
+
+    cy.contains('Edit document')
+  })
+
   // it('should handle the time series view properly', function() {
   //   cy.request(
   //     'POST',

--- a/test/e2e/cypress/integration/indexes.spec.js
+++ b/test/e2e/cypress/integration/indexes.spec.js
@@ -73,6 +73,8 @@ describe('Indexes', () => {
 
     cy.get('body').type('n{enter}')
 
+    cy.url().should('contain', 'nyc-open-data')
+    cy.contains('nyc-open-data')
     cy.contains('This index has no collections.')
   })
 })

--- a/test/e2e/cypress/integration/indexes.spec.js
+++ b/test/e2e/cypress/integration/indexes.spec.js
@@ -64,4 +64,15 @@ describe('Indexes', () => {
 
     cy.get('.IndexesPage').should('not.contain', indexName)
   })
+
+  it('Should be able to autofocus index search', () => {
+    cy.request('POST', 'http://localhost:7512/nyc-open-data/_create')
+    cy.request('POST', 'http://localhost:7512/iot-data/_create')
+
+    cy.waitOverlay()
+
+    cy.get('body').type('n{enter}')
+
+    cy.contains('This index has no collections.')
+  })
 })


### PR DESCRIPTION
## What does this PR do ?

This PR allows users to navigate through indexes and collections and then documents with keyboard inputs only.  

The index, collection filters and document QuickFilter are now instances of `AutoFocusInput` which listen to keyboard event to directly focus the corresponding input.  
Then this component can emit a `submit` event when `Enter` is pressed.

The index, collection and document list pages listen for this submit event to navigate to the first item of the filtered list.

![navigate-keyboard](https://user-images.githubusercontent.com/4447392/81252409-21e47a00-9026-11ea-8a22-fddc74db7e64.gif)

### Other changes

 - `DocumentListItem` is now responsible of pushing the `Update` route to the router when the update button is clicked
 - Fix collection breadcrumb
 - Fix https://github.com/kuzzleio/kuzzle-admin-console/issues/659