### PR TITLE
Fix missing breadcrumbs on create Role page

### DIFF
--- a/src/components/Common/Breadcrumb.vue
+++ b/src/components/Common/Breadcrumb.vue
@@ -41,7 +41,11 @@
         </router-link>
       </li>
 
-      <li v-if="isRouteActive('SecurityRolesList')">
+      <li v-if="isRouteActive([
+        'SecurityRolesList',
+        'SecurityRolesCreate',
+        'SecurityRolesUpdate'
+      ])">
         <i class="fa fa-angle-right separator" aria-hidden="true" />
 
         <router-link :to="{ name: 'SecurityRolesList' }">

--- a/src/components/Security/Roles/CreateOrUpdate.vue
+++ b/src/components/Security/Roles/CreateOrUpdate.vue
@@ -53,13 +53,13 @@
             <pre class="my-3 ml-3">
 {
   "controllers": {
-      "document": {
-        "actions": {
-          "get": true,
-          "search": true
-        }
+    "document": {
+      "actions": {
+        "get": true,
+        "search": true
       }
     }
+  }
 }
             </pre>
           </b-col>


### PR DESCRIPTION
## What does this PR do ?

Fix breadcrumb on "Create Role" and "Update Role" page.

Also, remove 2 extra spaces before `document` block