### PR TITLE
#695 Fix JSON env import

### DIFF
--- a/src/components/Common/Environments/ModalImport.vue
+++ b/src/components/Common/Environments/ModalImport.vue
@@ -55,7 +55,7 @@ export default {
     importEnv() {
       for (const name in this.env) {
         try {
-          this.$store.direct.dispatch.kuzzle.createEnvurinlent({
+          this.$store.direct.dispatch.kuzzle.createEnvironment({
             id: name,
             environment: this.env[name]
           })


### PR DESCRIPTION
## What does this PR do ?
Fix #695 : corrects typo on create env function call

### How should this be manually tested?
try to import a JSON file like this one : 
```
{
  "localEnv": {
    "name": "localhost",
    "color": "#002835",
    "host": "localhost",
    "port": 7512,
    "ssl": false
  }
}
```
