### PR TITLE
Fix dropdowns width

### DIFF
--- a/src/components/Data/Documents/Views/Column.vue
+++ b/src/components/Data/Documents/Views/Column.vue
@@ -10,7 +10,7 @@
           text="Select columns to display"
           no-flip
         >
-          <b-dropdown-text
+          <b-dropdown-item
             v-for="field of formattedSelectFields"
             :key="`dropdown-${field.text}`"
           >
@@ -28,15 +28,15 @@
                 class="inlineDisplay-item code pointer"
                 :for="field.text"
                 :title="field.text"
-                >{{ truncateName(field.text, 20) }}</label
+                >{{ field.text }}</label
               >
             </div>
-          </b-dropdown-text>
-          <b-dropdown-text v-if="formattedSelectFields.length === 0">
+          </b-dropdown-item>
+          <b-dropdown-item v-if="formattedSelectFields.length === 0">
             <span class="inlineDisplay-item">
               No searchable field
             </span>
-          </b-dropdown-text>
+          </b-dropdown-item>
         </b-dropdown>
         <b-button
           variant="outline-dark"

--- a/src/components/Data/Documents/Views/Column.vue
+++ b/src/components/Data/Documents/Views/Column.vue
@@ -10,28 +10,27 @@
           text="Select columns to display"
           no-flip
         >
-          <b-dropdown-item
+          <b-dropdown-text
+            class="dropdown-text inlineDisplay pointer p-0"
             v-for="field of formattedSelectFields"
             :key="`dropdown-${field.text}`"
           >
-            <div class="inlineDisplay pointer">
-              <span class="inlineDisplay-item">
-                <b-form-checkbox
-                  class="mx-2"
-                  :checked="field.displayed"
-                  :data-cy="`SelectField--${field.text}`"
-                  :id="field.text"
-                  @change="toggleColumn(field.text, $event)"
-                />
-              </span>
-              <label
-                class="inlineDisplay-item code pointer"
-                :for="field.text"
-                :title="field.text"
-                >{{ field.text }}</label
-              >
-            </div>
-          </b-dropdown-item>
+            <span class="inlineDisplay-item">
+              <b-form-checkbox
+                class="mx-2"
+                :checked="field.displayed"
+                :data-cy="`SelectField--${field.text}`"
+                :id="field.text"
+                @change="toggleColumn(field.text, $event)"
+              />
+            </span>
+            <label
+              class="inlineDisplay-item code pointer"
+              :for="field.text"
+              :title="field.text"
+              >{{ field.text }}</label
+            >
+          </b-dropdown-text>
           <b-dropdown-item v-if="formattedSelectFields.length === 0">
             <span class="inlineDisplay-item">
               No searchable field
@@ -102,7 +101,7 @@
           no-border-collapse
           small
           sort-icon-left
-          sticky-header="600px"
+          sticky-header
           striped
           :fields="formattedTableFields"
           :items="formattedItems"
@@ -110,10 +109,10 @@
           <template v-slot:head()="data">
             <div class="inlineDisplay mx-1">
               <span
-                class="inlineDisplay-item text-secondary m-3"
+                class="inlineDisplay-item text-secondary m-3 text-nowrap"
                 :data-cy="`ColumnViewHead--${data.label}`"
                 :title="data.label"
-                >{{ truncateName(getLastKeyPath(data.label), 20) }}</span
+                >{{ data.label }}</span
               >
             </div>
           </template>
@@ -174,11 +173,6 @@
               >
                 [...]
               </span>
-              <span
-                v-if="typeof data.value !== 'object'"
-                class="inlineDisplay-item px-3 code valueDisplayer"
-                >{{ data.value }}</span
-              >
               <b-badge
                 pill
                 class="mx-1"
@@ -195,6 +189,11 @@
                 This value cannot be displayed because it contains or is
                 contained in an array.
               </b-tooltip>
+              <span
+                v-if="typeof data.value !== 'object'"
+                class="inlineDisplay-item px-3 code valueDisplayer"
+                >{{ data.value }}</span
+              >
             </div>
           </template>
         </b-table>
@@ -488,7 +487,6 @@ export default {
 }
 
 .columnClass {
-  max-width: 300px;
   min-width: 100px;
   overflow: hidden;
 }
@@ -496,5 +494,17 @@ export default {
 .valueDisplayer {
   white-space: nowrap;
   display: inline-block;
+}
+
+.dropdown-text {
+  display: block;
+  width: 100%;
+  clear: both;
+  font-weight: 400;
+  color: #212529;
+  text-align: inherit;
+  white-space: nowrap;
+  background-color: transparent;
+  border: 0;
 }
 </style>

--- a/src/components/Data/Documents/Views/Column.vue
+++ b/src/components/Data/Documents/Views/Column.vue
@@ -10,6 +10,13 @@
           text="Select columns to display"
           no-flip
         >
+          <b-dropdown-item-button
+            v-if="selectedFields.length !== 0"
+            class="pl-4"
+            @click="resetColumns"
+          >
+            Unselect all
+          </b-dropdown-item-button>
           <b-dropdown-text
             class="dropdown-text inlineDisplay pointer p-0"
             v-for="field of formattedSelectFields"
@@ -329,6 +336,10 @@ export default {
     }
   },
   methods: {
+    resetColumns() {
+      this.selectedFields = []
+      this.saveSelectedFieldsToLocalStorage()
+    },
     truncateName,
     canDeleteDocument,
     isChecked(id) {

--- a/src/components/Security/Profiles/Filters.vue
+++ b/src/components/Security/Profiles/Filters.vue
@@ -12,7 +12,7 @@
             text="Select roles to be contained in the profiles"
             no-flip
           >
-            <b-dropdown-text v-for="role of roleList" :key="`dropdown-${role}`">
+            <b-dropdown-item v-for="role of roleList" :key="`dropdown-${role}`">
               <div
                 class="inlineDisplay pointer"
                 :data-cy="`RoleSelect--${role}`"
@@ -29,15 +29,15 @@
                   class="inlineDisplay-item code pointer"
                   :for="role"
                   :title="role"
-                  >{{ truncateName(role, 20) }}</label
+                  >{{ role }}</label
                 >
               </div>
-            </b-dropdown-text>
-            <b-dropdown-text v-if="roleList.length === 0">
+            </b-dropdown-item>
+            <b-dropdown-item v-if="roleList.length === 0">
               <span class="inlineDisplay-item">
                 No roles found.
               </span>
-            </b-dropdown-text>
+            </b-dropdown-item>
           </b-dropdown>
           <b-badge
             v-if="hasFilter"

--- a/src/components/Security/Profiles/Filters.vue
+++ b/src/components/Security/Profiles/Filters.vue
@@ -12,27 +12,27 @@
             text="Select roles to be contained in the profiles"
             no-flip
           >
-            <b-dropdown-item v-for="role of roleList" :key="`dropdown-${role}`">
-              <div
-                class="inlineDisplay pointer"
-                :data-cy="`RoleSelect--${role}`"
+            <b-dropdown-text
+              class="dropdown-text inlineDisplay pointer p-0"
+              :data-cy="`RoleSelect--${role}`"
+              v-for="role of roleList"
+              :key="`dropdown-${role}`"
+            >
+              <span class="inlineDisplay-item">
+                <b-form-checkbox
+                  class="mx-2"
+                  :checked="roleIsSelected(role)"
+                  :id="role"
+                  @change="toggleRole(role, $event)"
+                />
+              </span>
+              <label
+                class="inlineDisplay-item code pointer"
+                :for="role"
+                :title="role"
+                >{{ role }}</label
               >
-                <span class="inlineDisplay-item">
-                  <b-form-checkbox
-                    class="mx-2"
-                    :checked="roleIsSelected(role)"
-                    :id="role"
-                    @change="toggleRole(role, $event)"
-                  />
-                </span>
-                <label
-                  class="inlineDisplay-item code pointer"
-                  :for="role"
-                  :title="role"
-                  >{{ role }}</label
-                >
-              </div>
-            </b-dropdown-item>
+            </b-dropdown-text>
             <b-dropdown-item v-if="roleList.length === 0">
               <span class="inlineDisplay-item">
                 No roles found.
@@ -136,5 +136,16 @@ export default {
   &-item {
     display: table-cell;
   }
+}
+.dropdown-text {
+  display: block;
+  width: 100%;
+  clear: both;
+  font-weight: 400;
+  color: #212529;
+  text-align: inherit;
+  white-space: nowrap;
+  background-color: transparent;
+  border: 0;
 }
 </style>


### PR DESCRIPTION
## What does this PR do ?

About #673 :
 Resolved:
  - Display the full path (wthout truncate or dots) in the dropdown with auto resize width
  - Display the full path (without truncate of dots) in the table headers
  - Allow user to scroll horizontally in the table (since the headers might now take more width)
  - Add an `Unselect all` button in the dropdown to allow user reset the table columns

![acPR1-1](https://user-images.githubusercontent.com/44427849/83142734-3087f380-a0f1-11ea-8c6a-a4e7d8cbf75a.gif)

Can't reproduce:
  - The `undefined` values displayed at `null`
  - The `createdAt` property with `null` value
  - The double scrollbar with 25 results/page

About #658:
 Resolved:
  - Display the full path (wthout truncate or dots) in the dropdown with auto resize width

![acPR1-2](https://user-images.githubusercontent.com/44427849/83142746-341b7a80-a0f1-11ea-8492-93ea204e93e3.gif)

### How should this be manually tested?
  - Step 1 : Run kuzzle V2 with multiple Roles/Profiles and a collection with some long named properties
  - Step 2 : Search for profiles by selecting some roles 
  - Step 3 : Use the document column view, select multiples properties and scroll horizontally
 
### Other changes
/

### Boyscout
/

### Screenshots (if appropriate)
