### PR TITLE
Query result without user created

### DIFF
--- a/src/components/Data/Indexes/CreateIndexModal.vue
+++ b/src/components/Data/Indexes/CreateIndexModal.vue
@@ -6,6 +6,7 @@
     title="Index creation"
     :id="id"
     @hide="resetForm"
+    @close="hideModal"
   >
     <template v-slot:modal-footer>
       <b-button variant="secondary" @click="hideModal">
@@ -30,6 +31,7 @@
         <b-form-input
           data-cy="CreateIndexModal-name"
           id="indexName"
+          autofocus
           required
           type="text"
           v-model="index"
@@ -68,7 +70,8 @@ export default {
       this.index = ''
       this.error = ''
     },
-    hideModal() {
+    async hideModal() {
+      await this.$store.direct.dispatch.index.listIndexes()
       this.resetForm()
       this.$bvModal.hide(this.id)
     },
@@ -79,6 +82,7 @@ export default {
 
       try {
         await this.$store.direct.dispatch.index.createIndex(this.index)
+        await this.$store.direct.dispatch.index.listIndexes()
         this.hideModal()
       } catch (err) {
         this.error = err.message

--- a/src/components/Security/Users/CreateOrUpdate.vue
+++ b/src/components/Security/Users/CreateOrUpdate.vue
@@ -181,6 +181,7 @@ export default {
         this.setError(e.message)
         return
       }
+      this.loading = true
       this.submitting = true
 
       try {
@@ -222,12 +223,14 @@ export default {
         }
 
         this.$router.push({ name: 'SecurityUsersList' })
+        this.loading = false
       } catch (err) {
         if (err) {
           this.$log.error(err)
           this.setError(err.message)
           this.submitting = false
         }
+        this.loading = false
       }
     },
     setError(msg) {

--- a/src/components/Security/Users/List.vue
+++ b/src/components/Security/Users/List.vue
@@ -14,7 +14,7 @@
           />
         </b-col>
       </b-row>
-      <template v-if="fetchingUsers">
+      <template v-if="loading">
         <b-row class="text-center">
           <b-col>
             <b-spinner variant="primary" class="mt-5"></b-spinner>
@@ -113,7 +113,7 @@
           </div>
         </b-card-text>
       </b-card>
-      <b-row align-h="center">
+      <b-row align-h="center" v-if="!loading">
         <b-pagination
           class="m-2 mt-4"
           data-cy="UserManagement-pagination"
@@ -171,7 +171,7 @@ export default {
       currentPage: 1,
       deleteModalIsLoading: false,
       documents: [],
-      fetchingUsers: false,
+      loading: true,
       searchFilterOperands: filterManager.searchFilterOperands,
       selectedDocuments: [],
       totalDocuments: 0,
@@ -244,7 +244,7 @@ export default {
       }
     },
     async fetchDocuments() {
-      this.fetchingUsers = true
+      this.loading = true
 
       this.$forceUpdate()
 
@@ -290,7 +290,7 @@ export default {
           noAutoHide: true
         })
       }
-      this.fetchingUsers = false
+      this.loading = false
     },
     editUser(id) {
       this.$router.push({
@@ -303,17 +303,19 @@ export default {
     // =========================================================================
     async onDeleteConfirmed() {
       this.deleteModalIsLoading = true
+      this.loading = true
       try {
         await performDeleteUsers(
           this.index,
           this.collection,
           this.candidatesForDeletion
         )
-        this.$bvModal.hide('modal-delete-users')
         this.deleteModalIsLoading = false
-        this.fetchDocuments()
+        this.$bvModal.hide('modal-delete-users')
+        await this.fetchDocuments()
       } catch (e) {
         this.$log.error(e)
+        this.deleteModalIsLoading = false
         this.$bvToast.toast(
           'The complete error has been printed to the console.',
           {
@@ -325,6 +327,7 @@ export default {
           }
         )
       }
+      this.loading = false
     },
     deleteUser(id) {
       this.candidatesForDeletion.push(id)

--- a/src/components/Security/Users/List.vue
+++ b/src/components/Security/Users/List.vue
@@ -1,7 +1,14 @@
 <template>
   <div class="UserList">
+    <template v-if="loading">
+      <b-row class="text-center">
+        <b-col>
+          <b-spinner variant="primary" class="mt-5"></b-spinner>
+        </b-col>
+      </b-row>
+    </template>
     <slot v-if="isCollectionEmpty" name="emptySet" />
-    <template v-else>
+    <template v-if="!isCollectionEmpty && !loading">
       <b-row class="justify-content-md-center" no-gutters>
         <b-col cols="12">
           <filters
@@ -14,15 +21,7 @@
           />
         </b-col>
       </b-row>
-      <template v-if="loading">
-        <b-row class="text-center">
-          <b-col>
-            <b-spinner variant="primary" class="mt-5"></b-spinner>
-          </b-col>
-        </b-row>
-      </template>
       <b-card
-        v-else
         class="light-shadow"
         :bg-variant="documents.length === 0 ? 'light' : 'default'"
       >

--- a/src/components/Security/Users/List.vue
+++ b/src/components/Security/Users/List.vue
@@ -1,135 +1,135 @@
 <template>
   <div class="UserList">
     <slot v-if="isCollectionEmpty" name="emptySet" />
-    <b-row class="justify-content-md-center" no-gutters>
-      <b-col cols="12">
-        <filters
-          class="mb-3"
-          :available-operands="searchFilterOperands"
-          :current-filter="currentFilter"
-          :collection-mapping="collectionMapping"
-          @filters-updated="onFiltersUpdated"
-          @reset="onFiltersUpdated"
-        />
-      </b-col>
-    </b-row>
-    <template v-if="fetchingUsers">
-      <b-row class="text-center">
-        <b-col>
-          <b-spinner variant="primary" class="mt-5"></b-spinner>
+    <template v-else>
+      <b-row class="justify-content-md-center" no-gutters>
+        <b-col cols="12">
+          <filters
+            class="mb-3"
+            :available-operands="searchFilterOperands"
+            :current-filter="currentFilter"
+            :collection-mapping="collectionMapping"
+            @filters-updated="onFiltersUpdated"
+            @reset="onFiltersUpdated"
+          />
         </b-col>
       </b-row>
-    </template>
-    <b-card
-      v-else
-      class="light-shadow"
-      :bg-variant="documents.length === 0 ? 'light' : 'default'"
-    >
-      <b-card-text class="p-0">
-        <div v-show="!documents.length" class="row valign-center empty-set">
-          <b-row align-h="center" class="valign-center empty-set">
-            <b-col cols="2" class="text-center">
-              <i
-                class="fa fa-5x fa-search text-secondary mt-3"
-                aria-hidden="true"
-              />
-            </b-col>
-            <b-col md="6">
-              <h3 class="text-secondary font-weight-bold">
-                There is no result matching your query. Please try with
-                another filter.
-              </h3>
-              <p>
-                <em
-                  >Learn more about filtering syntax on
-                  <a
-                    href="https://docs.kuzzle.io/core/2/guides/cookbooks/elasticsearch/basic-queries/"
-                    target="_blank"
-                    >Kuzzle Elasticsearch Cookbook</a
-                  ></em
-                >
-              </p>
-            </b-col>
-          </b-row>
-        </div>
-
-        <div v-if="documents.length">
-          <b-row no-gutters class="mb-2">
-            <b-col cols="8">
-              <b-button
-                variant="outline-dark"
-                class="mr-2"
-                data-cy="UserList-toggleAllBtn"
-                @click="toggleAll"
-              >
+      <template v-if="fetchingUsers">
+        <b-row class="text-center">
+          <b-col>
+            <b-spinner variant="primary" class="mt-5"></b-spinner>
+          </b-col>
+        </b-row>
+      </template>
+      <b-card
+        v-else
+        class="light-shadow"
+        :bg-variant="documents.length === 0 ? 'light' : 'default'"
+      >
+        <b-card-text class="p-0">
+          <div v-show="!documents.length" class="row valign-center empty-set">
+            <b-row align-h="center" class="valign-center empty-set">
+              <b-col cols="2" class="text-center">
                 <i
-                  :class="
-                    `far ${
-                      allChecked ? 'fa-check-square' : 'fa-square'
-                    } left`
-                  "
+                  class="fa fa-5x fa-search text-secondary mt-3"
+                  aria-hidden="true"
                 />
-                Toggle all
-              </b-button>
-
-              <b-button
-                variant="outline-danger"
-                class="mr-2"
-                data-cy="UserList-bulkDeleteBtn"
-                :disabled="!displayBulkDelete"
-                @click="deleteBulk"
-              >
-                <i class="fa fa-minus-circle left" />
-                Delete selected
-              </b-button>
-            </b-col>
-          </b-row>
-        </div>
-
-        <div
-          v-show="documents.length"
-          class="row CrudlDocument-collection"
-          data-cy="UserList-items"
-        >
-          <div class="col s12">
-            <b-list-group class="w-100">
-              <b-list-group-item
-                v-for="document in documents"
-                class="p-2"
-                data-cy="UserList-item"
-                :key="document.id"
-              >
-                <UserItem
-                  :document="document"
-                  :is-checked="isChecked(document.id)"
-                  :index="index"
-                  :collection="collection"
-                  @checkbox-click="toggleSelectDocuments"
-                  @edit="editUser"
-                  @delete="deleteUser"
-                />
-              </b-list-group-item>
-            </b-list-group>
+              </b-col>
+              <b-col md="6">
+                <h3 class="text-secondary font-weight-bold">
+                  There is no result matching your query. Please try with
+                  another filter.
+                </h3>
+                <p>
+                  <em
+                    >Learn more about filtering syntax on
+                    <a
+                      href="https://docs.kuzzle.io/core/2/guides/cookbooks/elasticsearch/basic-queries/"
+                      target="_blank"
+                      >Kuzzle Elasticsearch Cookbook</a
+                    ></em
+                  >
+                </p>
+              </b-col>
+            </b-row>
           </div>
-        </div>
-      </b-card-text>
-    </b-card>
-    <b-row align-h="center">
-      <b-pagination
-        class="m-2 mt-4"
-        data-cy="UserManagement-pagination"
-        v-model="currentPage"
-        :total-rows="totalDocuments"
-        :per-page="paginationSize"
-      ></b-pagination>
-    </b-row>
-    <delete-modal
-      id="modal-delete-users"
-      :candidates-for-deletion="candidatesForDeletion"
-      :is-loading="deleteModalIsLoading"
-      @confirm="onDeleteConfirmed"
-      @hide="resetCandidatesForDeletion"
-    />
+
+          <div v-if="documents.length">
+            <b-row no-gutters class="mb-2">
+              <b-col cols="8">
+                <b-button
+                  variant="outline-dark"
+                  class="mr-2"
+                  data-cy="UserList-toggleAllBtn"
+                  @click="toggleAll"
+                >
+                  <i
+                    :class="
+                      `far ${allChecked ? 'fa-check-square' : 'fa-square'} left`
+                    "
+                  />
+                  Toggle all
+                </b-button>
+
+                <b-button
+                  variant="outline-danger"
+                  class="mr-2"
+                  data-cy="UserList-bulkDeleteBtn"
+                  :disabled="!displayBulkDelete"
+                  @click="deleteBulk"
+                >
+                  <i class="fa fa-minus-circle left" />
+                  Delete selected
+                </b-button>
+              </b-col>
+            </b-row>
+          </div>
+
+          <div
+            v-show="documents.length"
+            class="row CrudlDocument-collection"
+            data-cy="UserList-items"
+          >
+            <div class="col s12">
+              <b-list-group class="w-100">
+                <b-list-group-item
+                  v-for="document in documents"
+                  class="p-2"
+                  data-cy="UserList-item"
+                  :key="document.id"
+                >
+                  <UserItem
+                    :document="document"
+                    :is-checked="isChecked(document.id)"
+                    :index="index"
+                    :collection="collection"
+                    @checkbox-click="toggleSelectDocuments"
+                    @edit="editUser"
+                    @delete="deleteUser"
+                  />
+                </b-list-group-item>
+              </b-list-group>
+            </div>
+          </div>
+        </b-card-text>
+      </b-card>
+      <b-row align-h="center">
+        <b-pagination
+          class="m-2 mt-4"
+          data-cy="UserManagement-pagination"
+          v-model="currentPage"
+          :total-rows="totalDocuments"
+          :per-page="paginationSize"
+        ></b-pagination>
+      </b-row>
+      <delete-modal
+        id="modal-delete-users"
+        :candidates-for-deletion="candidatesForDeletion"
+        :is-loading="deleteModalIsLoading"
+        @confirm="onDeleteConfirmed"
+        @hide="resetCandidatesForDeletion"
+      />
+    </template>
   </div>
 </template>
 


### PR DESCRIPTION
## What does this PR do ?

Resolve: #711 

### How should this be manually tested?
  - Step 1 : Run kuzzle without user created and check security/users page, it should not display the filters neither the list or the not result for query message
  - Step 2 : Try all create index modal possibilities (cancel, ok, cross, click outside) the list should be up to date whatever you did

### Other changes
/

### Boyscout
Index creation (fix the following points):
  - Create index does not refresh the index list
  - Close the creation modal clear the index list 
  - Add input autofocus

User (fix the following points):
  - Add loading spinner on user creation page when creating
  - Deleting the last user (when logged as anonymous) add the loading spinner wich never end

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/44427849/83262267-fd129b00-a1bc-11ea-80f5-f68d73432b1f.png)



