### PR TITLE
check admin on user creation and deletion

### DIFF
--- a/src/components/Security/Users/CreateOrUpdate.vue
+++ b/src/components/Security/Users/CreateOrUpdate.vue
@@ -220,8 +220,15 @@ export default {
             },
             credentials: this.credentials
           })
+          if (!this.$store.direct.getters.auth.adminAlreadyExists) {
+            try {
+              await this.$store.direct.dispatch.auth.checkFirstAdmin()
+            } catch (err) {
+              this.$log.error(err)
+              this.setError(err.message)
+            }
+          }
         }
-
         this.$router.push({ name: 'SecurityUsersList' })
         this.loading = false
       } catch (err) {

--- a/src/components/Security/Users/List.vue
+++ b/src/components/Security/Users/List.vue
@@ -327,6 +327,14 @@ export default {
         this.deleteModalIsLoading = false
         this.$bvModal.hide('modal-delete-users')
         await this.fetchDocuments()
+        if (this.$store.direct.getters.auth.adminAlreadyExists) {
+          try {
+            await this.$store.direct.dispatch.auth.checkFirstAdmin()
+          } catch (err) {
+            this.$log.error(err)
+            this.setError(err.message)
+          }
+        }
       } catch (e) {
         this.$log.error(e)
         this.deleteModalIsLoading = false


### PR DESCRIPTION
## What does this PR do ?
Fix #716 :
  - After a user creation, check if there is an admin in kuzzle (only if there was no admin before creation) and hide the bottom alert if needed.
  - After a user deletion, check if there is an admin in kuzzle (only if there was an admin before deletion) and display the bottom alert if needed.

### How should this be manually tested?

  - Step 1 : Run an empty Kuzzle (The bottom alert is displayed)
  - Step 2 : Then create an admin (the alert should disappear)
  - Step 3 : Then delete it (the alert should be displayed again)

