### PR TITLE
[#736] Force editing malformed environement

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="App">
-    <main-spinner v-if="initializing"></main-spinner>
-    <template v-else>
+    <template>
       <router-view
         data-cy="App-loggedIn"
         @environment::create="editEnvironment"
@@ -41,47 +40,18 @@ import {} from './assets/global.scss'
 import ModalCreateOrUpdate from './components/Common/Environments/ModalCreateOrUpdate'
 import ModalDelete from './components/Common/Environments/ModalDelete'
 import ModalImport from './components/Common/Environments/ModalImport'
-import MainSpinner from './components/Common/MainSpinner'
 
 export default {
   name: 'KuzzleAdminConsole',
   components: {
     ModalCreateOrUpdate,
     ModalDelete,
-    ModalImport,
-    MainSpinner
+    ModalImport
   },
   data() {
     return {
-      initializing: true,
       environmentId: null
     }
-  },
-
-  async mounted() {
-    this.$log.debug('App:Mounted')
-    this.initializing = true
-    try {
-      // NOTE This operation is pretty useless here, as the environments must be
-      // loaded in the router guard. We double check here in order to display a
-      // warning if necessary, since we cannot show a toast from the router guard.
-      this.$store.direct.dispatch.kuzzle.loadEnvironments()
-    } catch (error) {
-      this.$log.error(error.message)
-      this.$log.error(localStorage.getItem('environments'))
-      this.$bvToast.toast(
-        'The list of saved connections seems to be malformed. If you know how to fix it, take a look at the console.',
-        {
-          title: 'Ooops! Something went wrong while loading the connections.',
-          variant: 'warning',
-          toaster: 'b-toaster-bottom-right',
-          appendToast: true,
-          dismissible: true,
-          noAutoHide: true
-        }
-      )
-    }
-    this.initializing = false
   },
   methods: {
     editEnvironment(id) {

--- a/src/components/Common/Environments/CreateEnvironment.vue
+++ b/src/components/Common/Environments/CreateEnvironment.vue
@@ -79,6 +79,8 @@
         <b-form-select
           data-cy="CreateEnvironment-backendVersion"
           v-model="environment.backendMajorVersion"
+          required
+          :state="versionState"
           :options="majorVersions"
         ></b-form-select>
       </b-form-group>
@@ -142,7 +144,7 @@ export default {
         port: 7512,
         color: DEFAULT_COLOR,
         ssl: useHttps,
-        backendMajorVersion: 2
+        backendMajorVersion: null
       },
       submitting: false
     }
@@ -220,8 +222,17 @@ export default {
       }
       return ''
     },
+    versionState() {
+      if (this.submitting) {
+        return true
+      }
+      // need ternary conditon because version can be null
+      return this.environment.backendMajorVersion ? true : false
+    },
     canSubmit() {
-      return this.hostState && this.nameState && this.portState
+      return (
+        this.hostState && this.nameState && this.portState && this.versionState
+      )
     }
   },
   mounted() {
@@ -240,7 +251,7 @@ export default {
       this.environment.port = 7512
       this.environment.color = DEFAULT_COLOR
       this.environment.ssl = useHttps
-      this.environment.backendMajorVersion = 2
+      this.environment.backendMajorVersion = null
     }
   },
   methods: {

--- a/src/components/Common/Environments/CreateEnvironment.vue
+++ b/src/components/Common/Environments/CreateEnvironment.vue
@@ -127,6 +127,7 @@ export default {
   data() {
     return {
       majorVersions: [
+        { value: null, text: 'Select version' },
         { value: 1, text: 'v1.x' },
         {
           value: 2,

--- a/src/components/Common/Environments/EnvironmentsSwitch.vue
+++ b/src/components/Common/Environments/EnvironmentsSwitch.vue
@@ -17,10 +17,18 @@
       :data-cy="`EnvironmentSwitch-env_${formatForDom(env.name)}`"
     >
       <div
-        @click="clickSwitch(index)"
+        @click="
+          checkEnvironment(env)
+            ? switchEnv(index)
+            : $emit('environment::create', index)
+        "
         class="EnvironmentSwitch-env-name text-truncate mr-3"
       >
         {{ env.name }}
+        <i
+          v-if="!checkEnvironment(env)"
+          class="fas fa-exclamation-triangle text-danger"
+        ></i>
         <div class="text-muted">{{ env.host }}</div>
       </div>
       <div class="EnvironmentSwitch-env-inputs">
@@ -54,6 +62,7 @@
 <script>
 import { formatForDom } from '../../../utils'
 import { mapValues, omit } from 'lodash'
+import { envColors } from '../../../vuex/modules/kuzzle/store'
 
 export default {
   name: 'EnvironmentSwitch',
@@ -95,9 +104,8 @@ export default {
       return URL.createObjectURL(blob)
     }
   },
-  mounted() {},
   methods: {
-    async clickSwitch(id) {
+    async switchEnv(id) {
       try {
         await this.$store.direct.dispatch.kuzzle.setCurrentEnvironment(id)
         this.$log.debug(`Switched.`)
@@ -108,6 +116,22 @@ export default {
           this.$store.direct.dispatch.kuzzle.onConnectionError(error)
         }
       }
+    },
+    checkEnvironment(env) {
+      if (
+        !env.name ||
+        !env.host ||
+        !env.port ||
+        !env.backendMajorVersion ||
+        typeof env.port !== 'number' ||
+        env.ssl === undefined ||
+        env.ssl === null ||
+        !env.color ||
+        !envColors.includes(env.color)
+      ) {
+        return false
+      }
+      return true
     },
     formatForDom
   }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -12,6 +12,7 @@ import Signup from '../components/Signup.vue'
 import DataLayout from '../components/Data/Layout.vue'
 import ResetPassword from '../components/ResetPassword.vue'
 import SecurityLayout from '../components/Security/Layout.vue'
+import PageNotFound from '../components/404.vue'
 
 import SecuritySubRoutes from './children/security'
 import DataSubRoutes from './children/data'
@@ -107,6 +108,11 @@ export default function createRoutes(log) {
             ]
           }
         ]
+      },
+      {
+        path: '*',
+        name: '404',
+        component: PageNotFound
       }
     ]
   })

--- a/src/vuex/modules/kuzzle/store.ts
+++ b/src/vuex/modules/kuzzle/store.ts
@@ -34,33 +34,6 @@ const wait = async ms =>
     }, ms)
   })
 
-const checkEnvironment = e => {
-  if (!e.name) {
-    throw new Error(`Invalid environment name: ${e.name}`)
-  }
-  if (!e.host) {
-    throw new Error(`Invalid environment host: ${e.host}`)
-  }
-  if (!e.port) {
-    throw new Error(`Invalid environment port: ${e.port}`)
-  }
-  if (typeof e.port !== 'number') {
-    throw new Error(
-      `Type of environment port is invalid: ${e.port} (must be a number)`
-    )
-  }
-  if (e.ssl === undefined || e.ssl === null) {
-    throw new Error('SSL parameter not found (must be a boolean)')
-  }
-  if (!e.color) {
-    throw new Error(`Invalid environment color: ${e.color}`)
-  }
-  if (!envColors.includes(e.color)) {
-    throw new Error(`Invalid environment color: ${e.color}`)
-  }
-  return true
-}
-
 const mutations = createMutations<KuzzleState>()({
   createEnvironment(state, payload) {
     if (!payload) {
@@ -70,11 +43,9 @@ const mutations = createMutations<KuzzleState>()({
       return
     }
     try {
-      if (checkEnvironment(payload.environment)) {
-        state.environments = {
-          ...state.environments,
-          [payload.id]: payload.environment
-        }
+      state.environments = {
+        ...state.environments,
+        [payload.id]: payload.environment
       }
     } catch (error) {
       throw new Error(`[${payload.id}] - ${error.message}`)

--- a/test/e2e/cypress/integration/single-backend/environments.spec.js
+++ b/test/e2e/cypress/integration/single-backend/environments.spec.js
@@ -310,7 +310,7 @@ describe('Environments', function() {
     })
   })
 
-  it.only('Should open edit modal when an environment is malformed', () => {
+  it('Should open edit modal when an environment is malformed', () => {
     localStorage.setItem(
       'environments',
       JSON.stringify({

--- a/test/e2e/cypress/integration/single-backend/environments.spec.js
+++ b/test/e2e/cypress/integration/single-backend/environments.spec.js
@@ -310,11 +310,29 @@ describe('Environments', function() {
     })
   })
 
-  it('Should display a toast when environment list is malformed', () => {
-    localStorage.setItem('environments', `{   Som3 m@l4rm3D CODEZ jayzon}}]}`)
+  it.only('Should open edit modal when an environment is malformed', () => {
+    localStorage.setItem(
+      'environments',
+      JSON.stringify({
+        ['malformedEnv']: {
+          name: 'malformedEnv',
+          color: 'darkblue',
+          host: 'localhost',
+          ssl: false,
+          port: 7512,
+          token: null
+          // missing backendMajorVersion
+        }
+      })
+    )
     cy.visit('/')
-    cy.contains('Ooops! Something went wrong while loading the connections.')
-    cy.url().should('contain', 'create-connection')
+    cy.get('[data-cy="EnvironmentSwitch"]').click()
+    cy.get('[data-cy="EnvironmentSwitch-env_malformedEnv"]').click()
+
+    cy.contains('Update Connection')
+    cy.get('[data-cy="CreateEnvironment-backendVersion"]').should($select => {
+      expect($select.attr('class')).to.contain('is-invalid')
+    })
   })
 
   it('Should display a spinner when connecting to an unavailable backend and connect automatically whe the backend is up', () => {

--- a/test/e2e/cypress/integration/single-backend/users.spec.js
+++ b/test/e2e/cypress/integration/single-backend/users.spec.js
@@ -451,7 +451,7 @@ describe('Users', function() {
       .contains('{')
       .click({ force: true })
     cy.get('textarea.ace_text-input')
-      .clear({ force: true })
+      .type('{selectall}{backspace}', { delay: 200, force: true })
       .type(
         `{
 "address": {


### PR DESCRIPTION
## What does this PR do ?
Fix #736 
As discussed, since it is impossible for us to automatically select the right version of the SDK depending on the environment and since we cannot force a default version. The proposed solution is to signal to the end user the environments that are malformed and when clicking on one of these environments force the opening of the editing modal.

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/3192870/84794795-faa2a480-aff6-11ea-8439-a843c2f3e234.png)

![image](https://user-images.githubusercontent.com/3192870/84794922-27ef5280-aff7-11ea-9768-7202f8639b81.png)

### Boyscout
* fix failing update user mapping test
