### PR TITLE
Add color state verification when editing an environment

### DIFF
--- a/src/components/Common/Environments/CreateEnvironment.vue
+++ b/src/components/Common/Environments/CreateEnvironment.vue
@@ -233,8 +233,8 @@ export default {
       if (this.submitting) {
         return true
       }
-      // need ternary conditon because version can be null
-      return this.environment.backendMajorVersion ? true : false
+
+      return this.environment.backendMajorVersion ? null : false
     },
     colorState() {
       if (this.submitting) {

--- a/src/components/Common/Environments/CreateEnvironment.vue
+++ b/src/components/Common/Environments/CreateEnvironment.vue
@@ -80,7 +80,7 @@
           data-cy="CreateEnvironment-backendVersion"
           v-model="environment.backendMajorVersion"
           required
-          :state="versionState"
+          :state="versionFeedback"
           :options="majorVersions"
         ></b-form-select>
       </b-form-group>
@@ -133,7 +133,7 @@ export default {
   data() {
     return {
       majorVersions: [
-        { value: null, text: 'Select version' },
+        { value: undefined, text: 'Select version' },
         { value: 1, text: 'v1.x' },
         {
           value: 2,
@@ -230,10 +230,9 @@ export default {
       return ''
     },
     versionState() {
-      if (this.submitting) {
-        return true
-      }
-
+      return this.environment.backendMajorVersion ? true : false
+    },
+    versionFeedback() {
       return this.environment.backendMajorVersion ? null : false
     },
     colorState() {

--- a/src/components/Common/Environments/CreateEnvironment.vue
+++ b/src/components/Common/Environments/CreateEnvironment.vue
@@ -230,6 +230,9 @@ export default {
       return ''
     },
     versionState() {
+      if (this.submitting) {
+        return true
+      }
       return this.environment.backendMajorVersion ? true : false
     },
     versionFeedback() {

--- a/src/components/Common/Environments/CreateEnvironment.vue
+++ b/src/components/Common/Environments/CreateEnvironment.vue
@@ -104,7 +104,7 @@
               class="CreateEnvironment-box-feedback text-danger ml-2"
               v-if="!colorState"
             >
-              You must select an environment color</span
+              <small> You must select an environment color</small></span
             >
           </b-row>
         </b-col>

--- a/src/components/Common/Environments/CreateEnvironment.vue
+++ b/src/components/Common/Environments/CreateEnvironment.vue
@@ -100,6 +100,12 @@
                 <span v-if="environment.color === color">Selected</span>
               </div>
             </b-col>
+            <span
+              class="CreateEnvironment-box-feedback text-danger ml-2"
+              v-if="!colorState"
+            >
+              You must select an environment color</span
+            >
           </b-row>
         </b-col>
       </b-row>
@@ -230,9 +236,19 @@ export default {
       // need ternary conditon because version can be null
       return this.environment.backendMajorVersion ? true : false
     },
+    colorState() {
+      if (this.submitting) {
+        return true
+      }
+      return this.colors.includes(this.environment.color)
+    },
     canSubmit() {
       return (
-        this.hostState && this.nameState && this.portState && this.versionState
+        this.hostState &&
+        this.nameState &&
+        this.portState &&
+        this.versionState &&
+        this.colorState
       )
     }
   },


### PR DESCRIPTION
## What does this PR do ?
Fix #753 
Add color state verification when editing an environment

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/3192870/85302602-a6416e00-b4a9-11ea-8a32-4714e2fbec76.png)


### Other changes
* shows version feedback only when the version is missing