### PR TITLE
#760 fix refresh collection list after delete

### DIFF
--- a/src/components/Data/Collections/CollectionList.vue
+++ b/src/components/Data/Collections/CollectionList.vue
@@ -387,7 +387,10 @@ export default {
           index: this.index,
           collection: this.collectionToDelete
         })
+
         this.$bvModal.hide('deleteCollectionPrompt')
+
+        await this.fetchStoredCollections()
       } catch (error) {
         this.$log.error(error)
         this.$bvToast.toast(

--- a/test/e2e/cypress/integration/single-backend/collections.spec.js
+++ b/test/e2e/cypress/integration/single-backend/collections.spec.js
@@ -23,7 +23,9 @@ describe('Collection management', function() {
     cy.get('[data-cy="CollectionCreateOrUpdate-submit"]').click({
       force: true
     })
-    cy.get(`[data-cy="CollectionList-name--${collectionName}"]`).click({force: true})
+    cy.get(`[data-cy="CollectionList-name--${collectionName}"]`).click({
+      force: true
+    })
     cy.contains(collectionName)
   })
 
@@ -84,7 +86,11 @@ describe('Collection management', function() {
     cy.get(`[data-cy="CollectionList-delete--${collectionName}"]`).click()
     cy.get('[data-cy="DeleteCollectionPrompt-confirm"]').type(collectionName)
     cy.get('[data-cy="DeleteCollectionPrompt-OK"]').click()
-    cy.should('not.contain', collectionName)
+
+    cy.get('[data-cy="CollectionList-table"]').should(
+      'not.contain',
+      collectionName
+    )
   })
 
   it('is able to fetch collections when index change', function() {

--- a/test/e2e/cypress/integration/single-backend/collections.spec.js
+++ b/test/e2e/cypress/integration/single-backend/collections.spec.js
@@ -77,6 +77,8 @@ describe('Collection management', function() {
   })
 
   it('is able to delete a collection', function() {
+    cy.skipOnBackendVersion(1)
+
     cy.request('PUT', `${kuzzleUrl}/${indexName}/${collectionName}`)
 
     cy.visit(`/#/data/`)

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -89,3 +89,15 @@ async function poll(url, state = 'up') {
 Cypress.Commands.add('waitForService', (url, state = 'up') => {
   return poll(url, state)
 })
+
+Cypress.Commands.add('skipOnBackendVersion', version => {
+  const currentEnvName = localStorage.getItem('currentEnv')
+  const currentEnv = JSON.parse(localStorage.getItem('environments'))[
+    currentEnvName
+  ]
+
+  if (currentEnv.backendMajorVersion === version) {
+    const ctx = cy.state('runnable').ctx
+    ctx.skip()
+  }
+})


### PR DESCRIPTION
## What does this PR do ?
Fix #760 
* refresh collections list after a collection was deleted
* also fix the related e2e test that was always successful

### How should this be manually tested?

  - Step 1 : create an index and a collection
  - Step 2 : go to the page `/data/<indexName>`
  - Step 3 :  try deleting the collection freshly created, the list should update without the deleted collection

### Other changes
Currently it was not possible to play tests only for Kuzzle v1 or Kuzzle v2. I added a custom Cypress command to skip some unwanted tests according to a version that is passed to it.
`cy.skipOnBackendVersion(<kuzzleVersion>)`
