### PR TITLE
#756 edit document in column view

### DIFF
--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -110,6 +110,7 @@
                       :all-checked="allChecked"
                       :current-page-size="paginationSize"
                       :total-documents="totalDocuments"
+                      @edit="onEditClicked"
                       @delete="onDeleteClicked"
                       @bulk-delete="onBulkDeleteClicked"
                       @change-page-size="changePaginationSize"
@@ -412,6 +413,12 @@ export default {
     onDeleteClicked(id) {
       this.candidatesForDeletion.push(id)
       this.$bvModal.show('modal-delete')
+    },
+    onEditClicked(id) {
+      this.$router.push({
+        name: 'UpdateDocument',
+        params: { id }
+      })
     },
     onRefresh() {
       this.fetchDocuments()

--- a/src/components/Data/Documents/Views/Column.vue
+++ b/src/components/Data/Documents/Views/Column.vue
@@ -136,6 +136,7 @@
                   title="Edit document"
                   variant="link"
                   class="px-0 mx-1"
+                  :data-cy="`ColumnView-table-edit-btn--${data.item.id}`"
                   :disabled="!canEdit"
                   @click="editDocument(data.item.id)"
                 >

--- a/test/e2e/cypress/integration/single-backend/docs.spec.js
+++ b/test/e2e/cypress/integration/single-backend/docs.spec.js
@@ -314,8 +314,8 @@ describe('Document update/replace', () => {
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 
     cy.get('[data-cy="CollectionDropdown"]').click()
-    cy.wait(500)
     cy.get('[data-cy="CollectionDropdown-column"]').click()
+    cy.wait(500)
     cy.get('[data-cy="ColumnView-table-edit-btn--myId"]').click()
     cy.wait(500)
     cy.contains('Edit document')

--- a/test/e2e/cypress/integration/single-backend/docs.spec.js
+++ b/test/e2e/cypress/integration/single-backend/docs.spec.js
@@ -309,7 +309,7 @@ describe('Document update/replace', () => {
     )
   })
 
-  it.only('Should be able edit a document on column view', function() {
+  it('Should be able edit a document on column view', function() {
     cy.waitOverlay()
     cy.visit(`/#/data/${indexName}/${collectionName}`)
 

--- a/test/e2e/cypress/integration/single-backend/docs.spec.js
+++ b/test/e2e/cypress/integration/single-backend/docs.spec.js
@@ -308,4 +308,16 @@ describe('Document update/replace', () => {
       }
     )
   })
+
+  it.only('Should be able edit a document on column view', function() {
+    cy.waitOverlay()
+    cy.visit(`/#/data/${indexName}/${collectionName}`)
+
+    cy.get('[data-cy="CollectionDropdown"]').click()
+    cy.wait(500)
+    cy.get('[data-cy="CollectionDropdown-column"]').click()
+    cy.get('[data-cy="ColumnView-table-edit-btn--myId"]').click()
+    cy.wait(500)
+    cy.contains('Edit document')
+  })
 })


### PR DESCRIPTION
## What does this PR do ?
Fix #756 
Handle edit event from column view

### How should this be manually tested?
  - Step 1 : go to the document list page
  - Step 2 : switch to column view
  - Step 3 : try to edit a document  
