### PR TITLE
Fix wrong error check of anonymous rights

### DIFF
--- a/src/vuex/modules/auth/store.ts
+++ b/src/vuex/modules/auth/store.ts
@@ -89,7 +89,7 @@ const actions = createActions({
 
       return commit.setAdminExists(true)
     } catch (error) {
-      if (error.status === 403) {
+      if (error.status === 403 || error.status === 401) {
         return commit.setAdminExists(true)
       } else {
         throw error


### PR DESCRIPTION
## What does this PR do ?
fix #780 

Before Kuzzle was returning a 403 error when anonymous user doesn't have the right to execute an action but it should be a 401

