### PR TITLE
Restore syntax error check in JSON Editor

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,15 +5,15 @@
     <title>Kuzzle Admin Console</title>
     <style>
       html {
-        /* We can avoid setting height:100vh on the grid container if we use height:100% 
-          on the root element and then all descendants up until the grid container. 
-          Using 100vh can be a simpler option, but the vh unit can be problematic on 
-          iOS and Android: https://nicolas-hoizey.com/articles/2015/02/18/viewport-height-is-taller-than-the-visible-part-of-the-document-in-some-mobile-browsers/ 
+        /* We can avoid setting height:100vh on the grid container if we use height:100%
+          on the root element and then all descendants up until the grid container.
+          Using 100vh can be a simpler option, but the vh unit can be problematic on
+          iOS and Android: https://nicolas-hoizey.com/articles/2015/02/18/viewport-height-is-taller-than-the-visible-part-of-the-document-in-some-mobile-browsers/
         */
         height: 100%;
         /* With our styles we should not have any cause for a scrollbar on the page itself,
           so this is not strictly necessary, but to be safe we can prevent scrollbars on
-          the full page. 
+          the full page.
         */
         overflow: hidden;
       }
@@ -108,7 +108,6 @@
       href="favicon-128.png"
       sizes="128x128"
     />
-    <meta http-equiv="Content-Security-Policy" content="script-src 'self'">
     <meta name="msapplication-TileColor" content="#FFFFFF" />
     <meta
       name="msapplication-TileImage"

--- a/src/components/Common/JsonEditor.vue
+++ b/src/components/Common/JsonEditor.vue
@@ -79,9 +79,10 @@ export default {
   mounted() {
     Vue.nextTick(() => {
       /* eslint no-undef: 0 */
-      editor = ace.edit(this.$refs.jsoneditor)
+      editor = ace.edit(this.$refs.jsoneditor, {
+        mode: 'ace/mode/json'
+      })
       editor.setTheme('ace/theme/tomorrow')
-      editor.getSession().setMode('ace/mode/json')
       editor.setFontSize(15)
       editor.getSession().setTabSize(2)
       editor.setReadOnly(this.readonly)

--- a/test/e2e/cypress/integration/single-backend/JSONEditor.spec.js
+++ b/test/e2e/cypress/integration/single-backend/JSONEditor.spec.js
@@ -1,0 +1,33 @@
+describe('JSON Editor', function() {
+  const kuzzleUrl = 'http://localhost:7512'
+  const indexName = 'testindex'
+
+  beforeEach(() => {
+    // reset database and setup
+    cy.request('POST', `${kuzzleUrl}/admin/_resetDatabase`)
+    cy.request('POST', `${kuzzleUrl}/${indexName}/_create`)
+
+    cy.initLocalEnv(Cypress.env('BACKEND_VERSION'))
+  })
+
+  it('Should show that there is an error when the input is syntactically invalid', function() {
+    cy.visit(`/#/data/${indexName}/create`)
+    cy.get('.CollectionCreate').should('be.visible')
+
+    cy.get('[data-cy="JSONEditor"] .ace_line')
+      .contains('{')
+      .click({ force: true })
+
+    cy.get('[data-cy="JSONEditor"] textarea.ace_text-input')
+      .clear({ force: true })
+      .type(`INVALID JSON`, {
+        delay: 200,
+        force: true
+      })
+
+    cy.get('[data-cy="JSONEditor"] .ace_gutter-active-line').should(
+      'have.class',
+      'ace_error'
+    )
+  })
+})


### PR DESCRIPTION
Fixes #779 by giving up the Content-Security Policy. Do we really want this? Is there a better alternative?