### PR TITLE
[UI] [Filters] Reduce wording redundancy

### DIFF
--- a/src/components/Common/Filters/Filters.vue
+++ b/src/components/Common/Filters/Filters.vue
@@ -34,25 +34,25 @@
             data-cy="Filters-basicTab"
             :active="complexFiltersSelectedTab === 'basic'"
             @click="complexFiltersSelectedTab = 'basic'"
-            >Advanced</b-nav-item
+            ><i class="fas fa-filter"></i>&nbsp;Advanced</b-nav-item
           >
           <b-nav-item
             data-cy="Filters-rawTab"
             :active="complexFiltersSelectedTab === 'raw'"
             @click="complexFiltersSelectedTab = 'raw'"
-            >Raw JSON</b-nav-item
+            ><i class="fas fa-scroll"></i>&nbsp;Raw JSON</b-nav-item
           >
           <b-nav-item
             data-cy="Filters-historyTab"
             :active="complexFiltersSelectedTab === 'history'"
             @click="complexFiltersSelectedTab = 'history'"
-            >History</b-nav-item
+            ><i class="fas fa-history"></i>&nbsp;History</b-nav-item
           >
           <b-nav-item
             data-cy="Filters-favoriteTab"
             :active="complexFiltersSelectedTab === 'favorite'"
             @click="complexFiltersSelectedTab = 'favorite'"
-            >Saved</b-nav-item
+            ><i class="fas fa-star"></i>&nbsp;Saved</b-nav-item
           >
           <i
             data-cy="Filters-close"

--- a/src/components/Common/Filters/Filters.vue
+++ b/src/components/Common/Filters/Filters.vue
@@ -34,25 +34,25 @@
             data-cy="Filters-basicTab"
             :active="complexFiltersSelectedTab === 'basic'"
             @click="complexFiltersSelectedTab = 'basic'"
-            >Advanced Filter</b-nav-item
+            >Advanced</b-nav-item
           >
           <b-nav-item
             data-cy="Filters-rawTab"
             :active="complexFiltersSelectedTab === 'raw'"
             @click="complexFiltersSelectedTab = 'raw'"
-            >Raw JSON Filter</b-nav-item
+            >Raw JSON</b-nav-item
           >
           <b-nav-item
             data-cy="Filters-historyTab"
             :active="complexFiltersSelectedTab === 'history'"
             @click="complexFiltersSelectedTab = 'history'"
-            >Filter History</b-nav-item
+            >History</b-nav-item
           >
           <b-nav-item
             data-cy="Filters-favoriteTab"
             :active="complexFiltersSelectedTab === 'favorite'"
             @click="complexFiltersSelectedTab = 'favorite'"
-            >favorite Filter</b-nav-item
+            >Saved</b-nav-item
           >
           <i
             data-cy="Filters-close"

--- a/src/components/Data/Collections/CollectionList.vue
+++ b/src/components/Data/Collections/CollectionList.vue
@@ -32,11 +32,11 @@
       </template>
       <template v-else>
         <b-row class="mb-3">
-          <b-col sm="6" class="text-secondary">
+          <b-col sm="2" class="text-secondary">
             {{ collections.length }}
             {{ collections.length === 1 ? 'collection' : 'collections' }}
           </b-col>
-          <b-col sm="6">
+          <b-col sm="10">
             <b-row>
               <b-col cols="6" class="text-right">
                 <b-button

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -5,14 +5,14 @@
       :class="{ 'DocumentList--containerFluid': listViewType !== 'list' }"
     >
       <b-row>
-        <b-col sm="8">
+        <b-col>
           <headline>
             <span class="code" :title="collection">{{
               truncateName(collection, 20)
             }}</span>
           </headline>
         </b-col>
-        <b-col class="text-right mt-3">
+        <b-col sm="6" class="text-right mt-3">
           <b-button
             variant="primary"
             :disabled="


### PR DESCRIPTION
## Before
<img width="566" alt="Screenshot 2020-09-07 at 15 14 26" src="https://user-images.githubusercontent.com/5023426/92391718-748d8a00-f11d-11ea-9f0a-c317afc75cec.png">

## After

<img width="566" alt="Screenshot 2020-09-07 at 15 23 28" src="https://user-images.githubusercontent.com/5023426/92392399-83c10780-f11e-11ea-9e24-1a6d2ced2f4c.png">

## Boyscout

* Fixed the width of the bulk action buttons of the index list
* Fixed the width of the action buttons on top of the document page