### PR TITLE
allow choose column order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14069,18 +14069,18 @@
       }
     },
     "kuzzle-sdk-v7": {
-      "version": "npm:kuzzle-sdk@7.4.0",
-      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-7.4.0.tgz",
-      "integrity": "sha512-DWj8nKTX87Cja43L6v1e6Q7bd7mQfGp3bXHvoxMw2k43Nbs4dKGKy/Upx94ZNoNKgN/W03bMJhtAMyJjsSJaKw==",
+      "version": "npm:kuzzle-sdk@7.4.1",
+      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-7.4.1.tgz",
+      "integrity": "sha512-JROmbucILLuOZJualIUMgk+Wdix/cOVH5GiLPnGRtYTHKr0ymtteEu+eL8aKWpRArYGVcJfN85QksWDCcSRXeg==",
       "requires": {
         "min-req-promise": "^1.0.1",
         "ws": "^7.3.1"
       },
       "dependencies": {
         "ws": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+          "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
         }
       }
     },
@@ -18683,6 +18683,11 @@
         "is-plain-obj": "^1.0.0"
       }
     },
+    "sortablejs": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+      "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -20337,6 +20342,14 @@
       "requires": {
         "@types/leaflet": "^1.2.11",
         "leaflet": "1.3.1"
+      }
+    },
+    "vuedraggable": {
+      "version": "2.24.3",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
+      "integrity": "sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==",
+      "requires": {
+        "sortablejs": "1.10.2"
       }
     },
     "vuejs-logger": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "vue-router": "^3.1.3",
     "vue-template-compiler": "^2.6.10",
     "vue2-leaflet": "^1.0.2",
+    "vuedraggable": "^2.24.3",
     "vuejs-logger": "1.5.4",
     "vuelidate": "^0.7.5",
     "vuex": "^3.1.2"

--- a/src/components/Data/Documents/HeaderTableView.vue
+++ b/src/components/Data/Documents/HeaderTableView.vue
@@ -1,0 +1,59 @@
+<template>
+  <b-th
+    :id="`header-col-${field}`"
+    class="draggableItem"
+    @mouseenter="$emit('mouseenter')"
+    @mouseleave="$emit('mouseleave')"
+  >
+    <div class="table-head">
+      <i
+        :class="
+          `handle fas fa-arrows-alt ${displayDragIcon ? '' : 'hideDragIcon'}`
+        "
+      />
+      <span class="pr-2">{{ field }}</span>
+    </div>
+  </b-th>
+</template>
+
+<script>
+export default {
+  name: 'HeaderTableView',
+  props: {
+    field: {
+      type: String,
+      default: ''
+    },
+    displayDragIcon: {
+      default: false,
+      type: Boolean
+    }
+  },
+  data() {
+    return {}
+  },
+  methods: {},
+  mounted() {}
+}
+</script>
+
+<style lang="scss">
+.hideDragIcon {
+  visibility: hidden;
+}
+
+.table-head {
+  display: table;
+  width: 100%;
+  i,
+  .handle {
+    display: table-cell;
+    width: 20px;
+    max-width: 20px;
+  }
+
+  span {
+    display: table-cell;
+  }
+}
+</style>

--- a/src/components/Data/Documents/HeaderTableView.vue
+++ b/src/components/Data/Documents/HeaderTableView.vue
@@ -2,6 +2,7 @@
   <b-th
     :id="`header-col-${field}`"
     class="draggableItem"
+    :data-cy="`ColumnViewHead--${field}`"
     @mouseenter="$emit('mouseenter')"
     @mouseleave="$emit('mouseleave')"
   >

--- a/src/components/Data/Documents/Views/Column.vue
+++ b/src/components/Data/Documents/Views/Column.vue
@@ -100,7 +100,9 @@
     </b-row>
     <b-row class="mt-2 mb-2" no-gutters>
       <b-col cols="3">
-        <b-table-simple responsive striped hover bordered>
+        <b-table-simple responsive striped hover bordered
+          data-cy="ColumnView-table-id"
+        >
           <b-thead>
             <b-tr>
               <b-th
@@ -126,6 +128,7 @@
                     <span class="inlineDisplay-item">
                       <b-form-checkbox
                         :checked="isChecked(item.id)"
+                        :data-cy="`ColumnView-table-select-btn--${item.id}`"
                         @change="toggleSelectDocument(item.id)"
                       />
                     </span>
@@ -134,7 +137,7 @@
                         title="Edit document"
                         variant="link"
                         class="px-0 mx-1"
-                        :cy="`ColumnView-table-edit-btn--${item.id}`"
+                        :data-cy="`ColumnView-table-edit-btn--${item.id}`"
                         :disabled="!canEdit"
                         @click="editDocument(item.id)"
                       >
@@ -146,6 +149,7 @@
                         class="px-0 mx-1"
                         title="Delete document"
                         variant="link"
+                        :data-cy="`ColumnView-table-delete-btn--${item.id}`"
                         :disabled="!canDelete"
                         @click="deleteDocument(item.id)"
                       >
@@ -163,7 +167,9 @@
         </b-table-simple>
       </b-col>
       <b-col cols="9">
-        <b-table-simple responsive striped hover bordered>
+        <b-table-simple responsive striped hover bordered
+          data-cy="ColumnView-table-data"
+        >
           <b-thead>
             <draggable
               v-model="selectedFields"

--- a/src/components/Data/Documents/Views/Column.vue
+++ b/src/components/Data/Documents/Views/Column.vue
@@ -123,7 +123,7 @@
               >
             </div>
           </template>
-          <template v-slot:cell(actions)="data">
+          <template v-slot:cell(acColumnTableActions)="data">
             <div class="inlineDisplay">
               <span class="inlineDisplay-item">
                 <b-form-checkbox
@@ -156,7 +156,7 @@
               </span>
             </div>
           </template>
-          <template v-slot:cell(id)="data">
+          <template v-slot:cell(acColumnTableId)="data">
             <span data-cy="ColumnViewCell--id" class="code">{{
               data.item.id
             }}</span>
@@ -256,9 +256,9 @@ export default {
       }))
     },
     formattedTableFields() {
-      return [
+      const fields = [
         {
-          key: 'actions',
+          key: 'acColumnTableActions',
           label: '',
           deletable: false,
           stickyColumn: true,
@@ -267,30 +267,24 @@ export default {
           thClass: 'align-middle'
         },
         {
-          key: 'id',
+          key: 'acColumnTableId',
+          label: 'Id',
           deletable: false,
           sortable: true,
           tdClass: 'align-middle',
           thClass: 'align-middle'
         }
       ]
-        .concat(
-          this.fieldList.map((field, index) => ({
-            key: field,
-            index: index,
-            sortable: true,
-            deletable: true,
-            tdClass: 'align-middle columnClass',
-            thClass: 'align-middle'
-          }))
-        )
-        .filter(field => {
-          return (
-            field.key === 'id' ||
-            field.key === 'actions' ||
-            this.selectedFields.includes(field.key)
-          )
+      for (const f of this.selectedFields) {
+        fields.push({
+          key: f,
+          sortable: true,
+          deletable: true,
+          tdClass: 'align-middle columnClass',
+          thClass: 'align-middle'
         })
+      }
+      return fields
     },
     formattedItems() {
       return this.documents.map(d => {
@@ -298,7 +292,7 @@ export default {
         doc.id = d.id
         for (const { key } of this.formattedTableFields) {
           // each columns path
-          if (key === 'id') continue // column id is always ok
+          if (key === 'acColumnTableId' || key === 'acColumnTableActions') continue // column id is always ok
           // if there is an array in the current document within the 'path'
           if (this.documentPathContainsArray(key, d)) {
             doc[key] = { array: true }

--- a/src/components/Security/Roles/List.vue
+++ b/src/components/Security/Roles/List.vue
@@ -5,7 +5,6 @@
       <filters
         class="mb-3"
         :current-filter="currentFilter.basic"
-        
         @filters-updated="onFiltersUpdated"
         @reset="onFiltersUpdated"
       />

--- a/test/e2e/cypress/integration/single-backend/docs.spec.js
+++ b/test/e2e/cypress/integration/single-backend/docs.spec.js
@@ -131,16 +131,16 @@ describe('Document List', function() {
 
     cy.get('[data-cy="SelectField"]').click()
     cy.get('[data-cy="SelectField--date"]').click({ force: true })
-    cy.get('[data-cy="ColumnViewHead--Date"]').should('exist')
+    cy.get('[data-cy="ColumnViewHead--date"]').should('exist')
     cy.get('[data-cy="SelectField"]').click()
     cy.get('[data-cy="SelectField--date"]').click({ force: true })
-    cy.get('[data-cy="ColumnViewHead--Date"]').should('not.exist')
+    cy.get('[data-cy="ColumnViewHead--date"]').should('not.exist')
     cy.get('[data-cy="SelectField"]').click()
     cy.get('[data-cy="SelectField--value"]').click({ force: true })
     cy.get('[data-cy="SelectField"]').click()
     cy.get('[data-cy="SelectField--value2"]').click({ force: true })
-    cy.get('[data-cy="ColumnViewHead--Value"]').should('exist')
-    cy.get('[data-cy="ColumnViewHead--Value2"]').should('exist')
+    cy.get('[data-cy="ColumnViewHead--value"]').should('exist')
+    cy.get('[data-cy="ColumnViewHead--value2"]').should('exist')
   })
 
   it.skip('Should handle the time series view properly', function() {

--- a/test/e2e/cypress/integration/single-backend/search.spec.js
+++ b/test/e2e/cypress/integration/single-backend/search.spec.js
@@ -336,27 +336,27 @@ describe('Search', function() {
 
     cy.get('[data-cy="CollectionDropdownView"]').click()
     cy.get('[data-cy=CollectionDropdown-column]').click()
-    cy.get('[data-cy="ColumnView-table"] tbody tr').should('have.length', 1)
+    cy.get('[data-cy="ColumnView-table-id"] tbody tr').should('have.length', 1)
 
     cy.get('[data-cy="QuickFilter-resetBtn"]').click()
 
     cy.url().should('not.contain', 'Keylogger')
     cy.url().should('contain', 'listViewType=column')
-    cy.get('[data-cy="ColumnView-table"] tbody tr').should('have.length', 2)
+    cy.get('[data-cy="ColumnView-table-id"] tbody tr').should('have.length', 2)
 
     cy.get('[data-cy="QuickFilter-optionBtn"]').click()
     cy.get('[data-cy="Filters-basicTab"]').click()
     cy.get('[data-cy="BasicFilter-attributeSelect--0.0"]').select('job')
     cy.get('[data-cy="BasicFilter-valueInput--0.0"]').type('Keylogger')
     cy.get('[data-cy=BasicFilter-submitBtn]').click()
-    cy.get('[data-cy="ColumnView-table"] tbody tr').should('have.length', 1)
+    cy.get('[data-cy="ColumnView-table-id"] tbody tr').should('have.length', 1)
 
     cy.get('[data-cy="QuickFilter-displayActiveFilters"]').click()
     cy.get('[data-cy=Filters-basicTab]').click()
     cy.get('[data-cy="BasicFilter-resetBtn"]').click()
     cy.url().should('not.contain', 'Keylogger')
     cy.url().should('contain', 'listViewType=column')
-    cy.get('[data-cy="ColumnView-table"] tbody tr').should('have.length', 2)
+    cy.get('[data-cy="ColumnView-table-id"] tbody tr').should('have.length', 2)
   })
 
   it('sorts the results when sorting is selected in the basic filter', function() {


### PR DESCRIPTION
## What does this PR do ?
resolve #798 
Allow user to choose column order

The columns are added in the order we select the fields in the dropdown. Then we are able to drag and drop the columns to replace them.

By adding this feature, we can't sort the table by columns (using carets) anymore but since this feature was bugged, it will be added in another PR linked to another issue. #844 

### How should this be manually tested?
  - Step 1 : run console and connect to a kuzzle with a collection and a mapping with multiple fields
  - Step 2 : use the selectbox to add fields to the table 
  - Step 3 : drag and drop the columns to replace them (clicking on the cross-arrows icon)

### Other changes
/

### Boyscout
/

### Screenshots (if appropriate)
/
