### PR TITLE
add dropdown to select controllers

### DIFF
--- a/src/components/Security/Roles/Filters.vue
+++ b/src/components/Security/Roles/Filters.vue
@@ -12,14 +12,13 @@
             />
           </div>
         </b-col>
-        <b-col cols="2">
+        <b-col cols="2" v-if="availableControllers.length !== 0">
           <b-dropdown text="Controllers">
             <b-dropdown-item
               v-for="controller of availableControllers"
               :key="`dropdownControllers-${controller}`"
               :disabled="controllers.includes(controller)"
               @click="addControllerTag(controller)"
-
             >
               {{ controller }}
             </b-dropdown-item>
@@ -69,11 +68,15 @@ export default {
       this.controllers.push(controller)
     },
     async getKuzzlePublicApi() {
-      const publicApi = await this.$kuzzle.query({
-        controller: 'server',
-        action: 'publicApi'
-      })
-      this.availableControllers = Object.keys(publicApi.result)
+      try {
+        const publicApi = await this.$kuzzle.query({
+          controller: 'server',
+          action: 'publicApi'
+        });
+        this.availableControllers = Object.keys(publicApi.result)
+      } catch (error) {
+        this.$log.error(error)
+      }
     }
   },
   mounted() {

--- a/src/components/Security/Roles/Filters.vue
+++ b/src/components/Security/Roles/Filters.vue
@@ -13,7 +13,7 @@
           </div>
         </b-col>
         <b-col cols="2" v-if="availableControllers.length !== 0">
-          <b-dropdown text="Controllers">
+          <b-dropdown text="Controllers" :disabled="disableDropdown" id="controllers-dropdown">
             <b-dropdown-item
               v-for="controller of availableControllers"
               :key="`dropdownControllers-${controller}`"
@@ -23,6 +23,9 @@
               {{ controller }}
             </b-dropdown-item>
           </b-dropdown>
+          <b-tooltip target="controllers-dropdown" triggers="hover" v-if="disableDropdown">
+            Unable to retrieve controller list
+          </b-tooltip>
         </b-col>
         <b-col class="text-right">
           <b-button
@@ -54,7 +57,8 @@ export default {
   data() {
     return {
       controllers: [],
-      availableControllers: []
+      availableControllers: [],
+      disableDropdown: false
     }
   },
   methods: {
@@ -75,6 +79,7 @@ export default {
         })
         this.availableControllers = Object.keys(publicApi.result)
       } catch (error) {
+        this.disableDropdown = true
         this.$log.error(error)
       }
     }

--- a/src/components/Security/Roles/Filters.vue
+++ b/src/components/Security/Roles/Filters.vue
@@ -2,7 +2,7 @@
   <b-card no-body data-cy="RolesFilters" class="RolesFilters">
     <template v-slot:header>
       <b-row>
-        <b-col cols="10">
+        <b-col cols="8">
           <div class="RolesFilters-searchBar">
             <i class="RolesFilters-searchIcon fa fa-search" />
             <b-form-tags
@@ -12,7 +12,19 @@
             />
           </div>
         </b-col>
+        <b-col cols="2">
+          <b-dropdown text="Controllers">
+            <b-dropdown-item
+              v-for="controller of availableControllers"
+              :key="`dropdownControllers-${controller}`"
+              :disabled="controllers.includes(controller)"
+              @click="addControllerTag(controller)"
 
+            >
+              {{ controller }}
+            </b-dropdown-item>
+          </b-dropdown>
+        </b-col>
         <b-col class="text-right">
           <b-button
             class="mr-2"
@@ -29,20 +41,39 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 export default {
   name: 'RolesFilters',
   components: {},
   props: {
     currentFilter: Object
   },
+  computed: {
+    ...mapGetters('kuzzle', ['$kuzzle'])
+  },
   data() {
     return {
-      controllers: []
+      controllers: [],
+      availableControllers: []
     }
   },
   methods: {
     resetSearch() {
       this.controllers = []
+    },
+    addControllerTag(controller) {
+      if (this.controllers.includes(controller)) {
+        return
+      }
+      this.controllers.push(controller)
+    },
+    async getKuzzlePublicApi() {
+      const publicApi = await this.$kuzzle.query({
+        controller: 'server',
+        action: 'publicApi'
+      })
+      this.availableControllers = Object.keys(publicApi.result)
     }
   },
   mounted() {
@@ -50,6 +81,7 @@ export default {
       this.currentFilter && this.currentFilter.controllers
         ? this.currentFilter.controllers
         : []
+    this.getKuzzlePublicApi()
   },
   watch: {
     controllers: {

--- a/src/components/Security/Roles/Filters.vue
+++ b/src/components/Security/Roles/Filters.vue
@@ -72,7 +72,7 @@ export default {
         const publicApi = await this.$kuzzle.query({
           controller: 'server',
           action: 'publicApi'
-        });
+        })
         this.availableControllers = Object.keys(publicApi.result)
       } catch (error) {
         this.$log.error(error)


### PR DESCRIPTION
## What does this PR do ?
resolve #663 
Add a dropdown to filter on controllers easier when searching roles 

### How should this be manually tested?
  - Step 1 : run console with a kuzzle with multiples roles 
  - Step 2 : go on security roles page
  - Step 3 : use the dropdown to select some controllers to filter on

### Other changes
/

### Boyscout
/
### Screenshots (if appropriate)
![Capture du 2020-10-29 15-57-41](https://user-images.githubusercontent.com/44427849/97591063-84c83400-19ff-11eb-8894-c459dd83d3d8.png)

