### PR TITLE
add warning when edit profile or role

### DIFF
--- a/src/components/Security/Profiles/Update.vue
+++ b/src/components/Security/Profiles/Update.vue
@@ -5,7 +5,7 @@
     </Headline>
     <Notice />
     <b-alert variant="warning" :show="displayWarningAlert">
-      Warning, you are editing a profile that apply to yourself!
+      Warning, you are editing a profile that applies to yourself!
     </b-alert>
     <create-or-update
       v-if="!loading"

--- a/src/components/Security/Profiles/Update.vue
+++ b/src/components/Security/Profiles/Update.vue
@@ -5,7 +5,7 @@
     </Headline>
     <Notice />
     <b-alert variant="warning" :show="displayWarningAlert">
-     Warning, you are editing a profile that apply to yourself!
+      Warning, you are editing a profile that apply to yourself!
     </b-alert>
     <create-or-update
       v-if="!loading"
@@ -48,7 +48,7 @@ export default {
     ...mapGetters('kuzzle', ['$kuzzle']),
     ...mapGetters('auth', ['userProfiles']),
     displayWarningAlert() {
-      return this.userProfiles.includes(id)
+      return this.userProfiles.includes(this.id)
     }
   },
   methods: {

--- a/src/components/Security/Profiles/Update.vue
+++ b/src/components/Security/Profiles/Update.vue
@@ -4,6 +4,9 @@
       Edit profile - <span class="bold">{{ id }}</span>
     </Headline>
     <Notice />
+    <b-alert variant="warning" :show="displayWarningAlert">
+     Warning, you are editing a profile that apply to yourself!
+    </b-alert>
     <create-or-update
       v-if="!loading"
       :id="id"
@@ -42,7 +45,11 @@ export default {
     }
   },
   computed: {
-    ...mapGetters('kuzzle', ['$kuzzle'])
+    ...mapGetters('kuzzle', ['$kuzzle']),
+    ...mapGetters('auth', ['userProfiles']),
+    displayWarningAlert() {
+      return this.userProfiles.includes(id)
+    }
   },
   methods: {
     async onSubmit({ profile }) {

--- a/src/components/Security/Profiles/Update.vue
+++ b/src/components/Security/Profiles/Update.vue
@@ -48,7 +48,8 @@ export default {
     ...mapGetters('kuzzle', ['$kuzzle']),
     ...mapGetters('auth', ['userProfiles']),
     displayWarningAlert() {
-      return this.userProfiles.includes(this.id)
+
+      return this.userProfiles && this.userProfiles.includes(this.id)
     }
   },
   methods: {

--- a/src/components/Security/Roles/CreateOrUpdate.vue
+++ b/src/components/Security/Roles/CreateOrUpdate.vue
@@ -11,7 +11,7 @@
     </Headline>
     <Notice />
     <b-alert variant="warning" :show="displayWarningAlert">
-      Warning, you are editing a role that apply to yourself!
+      Warning, you are editing a role that applies to yourself!
     </b-alert>
     <template v-if="loading"></template>
     <template v-else>

--- a/src/components/Security/Roles/CreateOrUpdate.vue
+++ b/src/components/Security/Roles/CreateOrUpdate.vue
@@ -188,10 +188,10 @@ export default {
   },
   methods: {
     async searchAttachedProfiles() {
-      const res = await this.$kuzzle.security.searchProfiles(
-        { roles: [this.id] }
-      );
-      this.attachedProfiles = res.hits.map(p => p._id);
+      const res = await this.$kuzzle.security.searchProfiles({
+        roles: [this.id]
+      })
+      this.attachedProfiles = res.hits.map(p => p._id)
     },
     validateState(fieldName) {
       const { $dirty, $error } = this.$v[fieldName]
@@ -244,7 +244,7 @@ export default {
     }
     try {
       this.loading = true
-      this.searchAttachedProfiles();
+      this.searchAttachedProfiles()
       const fetchedRole = await this.$kuzzle.security.getRole(this.id)
       this.idValue = fetchedRole._id
       const role = omit(fetchedRole, ['_id', '_kuzzle'])

--- a/src/components/Security/Roles/CreateOrUpdate.vue
+++ b/src/components/Security/Roles/CreateOrUpdate.vue
@@ -188,10 +188,14 @@ export default {
   },
   methods: {
     async searchAttachedProfiles() {
-      const res = await this.$kuzzle.security.searchProfiles({
-        roles: [this.id]
-      })
-      this.attachedProfiles = res.hits.map(p => p._id)
+      try {
+        const res = await this.$kuzzle.security.searchProfiles({
+          roles: [this.id]
+        })
+        this.attachedProfiles = res.hits.map(p => p._id)
+      } catch (error) {
+        this.$log.error(err)
+      }
     },
     validateState(fieldName) {
       const { $dirty, $error } = this.$v[fieldName]

--- a/src/components/Security/Roles/CreateOrUpdate.vue
+++ b/src/components/Security/Roles/CreateOrUpdate.vue
@@ -194,7 +194,7 @@ export default {
         })
         this.attachedProfiles = res.hits.map(p => p._id)
       } catch (error) {
-        this.$log.error(err)
+        this.$log.error(error)
       }
     },
     validateState(fieldName) {

--- a/src/components/Security/Roles/CreateOrUpdate.vue
+++ b/src/components/Security/Roles/CreateOrUpdate.vue
@@ -10,6 +10,9 @@
       Create a new role
     </Headline>
     <Notice />
+    <b-alert variant="warning" :show="displayWarningAlert">
+      Warning, you are editing a role that apply to yourself!
+    </b-alert>
     <template v-if="loading"></template>
     <template v-else>
       <b-card class="h-100">
@@ -134,7 +137,7 @@ import { startsWithSpace, isWhitespace } from '../../../validators'
 import Headline from '../../Materialize/Headline'
 import Notice from '../Common/Notice'
 import JsonEditor from '../../Common/JsonEditor'
-import omit from 'lodash/omit'
+import { omit, intersection } from 'lodash'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -155,7 +158,8 @@ export default {
       documentValue: '{}',
       idValue: null,
       loading: false,
-      submitting: false
+      submitting: false,
+      attachedProfiles: []
     }
   },
   validations: {
@@ -176,9 +180,19 @@ export default {
     }
   },
   computed: {
-    ...mapGetters('kuzzle', ['$kuzzle'])
+    ...mapGetters('kuzzle', ['$kuzzle']),
+    ...mapGetters('auth', ['userProfiles']),
+    displayWarningAlert() {
+      return intersection(this.attachedProfiles, this.userProfiles).length !== 0
+    }
   },
   methods: {
+    async searchAttachedProfiles() {
+      const res = await this.$kuzzle.security.searchProfiles(
+        { roles: [this.id] }
+      );
+      this.attachedProfiles = res.hits.map(p => p._id);
+    },
     validateState(fieldName) {
       const { $dirty, $error } = this.$v[fieldName]
       return $dirty ? !$error : null
@@ -230,6 +244,7 @@ export default {
     }
     try {
       this.loading = true
+      this.searchAttachedProfiles();
       const fetchedRole = await this.$kuzzle.security.getRole(this.id)
       this.idValue = fetchedRole._id
       const role = omit(fetchedRole, ['_id', '_kuzzle'])

--- a/src/vuex/modules/auth/getters.ts
+++ b/src/vuex/modules/auth/getters.ts
@@ -62,6 +62,9 @@ export const getters = createGetters<AuthState>()({
   user(state): SessionUser {
     return state.user
   },
+  userProfiles(state) {
+    return state.user.params.profileIds
+  },
   tokenValid(state): boolean {
     return state.tokenValid
   },


### PR DESCRIPTION
## What does this PR do ?
resolve #830 
Add warning alert when editing role or profile that apply to current user 

### How should this be manually tested?
  - Step 1 : run console and kuzzle with profile/role
  - Step 2 : login
  - Step 3 : edit a profile/role that apply to yourself
  ...

### Other changes
/

### Boyscout
/
### Screenshots (if appropriate)

![Capture du 2020-10-29 13-04-25](https://user-images.githubusercontent.com/44427849/97569754-a0bfdb80-19e7-11eb-9f10-c86411a9395b.png)

![Capture du 2020-10-29 13-04-36](https://user-images.githubusercontent.com/44427849/97569542-930a5600-19e7-11eb-9972-4fd4f789cab6.png)

