### PR TITLE
Fix duplicate volatile collections already presents as stored collection

### DIFF
--- a/src/vuex/modules/index/store.ts
+++ b/src/vuex/modules/index/store.ts
@@ -130,9 +130,22 @@ const actions = createActions({
 
     const result = await rootGetters.kuzzle.$kuzzle.collection.list(index.name)
 
-    const collections = result.collections.map(el => {
-      return new Collection(el.name, el.type)
-    })
+    const collections = result.collections
+      .filter(el => {
+        if (
+          el.type === CollectionType.REALTIME &&
+          result.collections.find(
+            findEl =>
+              findEl.name === el.name && findEl.type === CollectionType.STORED
+          )
+        ) {
+          return false
+        }
+        return true
+      })
+      .map(el => {
+        return new Collection(el.name, el.type)
+      })
 
     if (!index.collections) {
       commit.setCollections({


### PR DESCRIPTION
## What does this PR do ?
Fix #848 
Prevents the addition of volatile collections already present as stored in the store

### How should this be manually tested?
* Go to next-console.kuzzle.io and switch to realtime view for a stored collection
* Run the AC locally
* Browse the same collection on an other tab and check there is no duplicate on the collection list

