### PR TITLE
852 disable sort text field

### DIFF
--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -263,7 +263,11 @@ export default {
   computed: {
     ...mapGetters('kuzzle', ['wrapper']),
     selectAttributesValues() {
-      return Object.keys(this.mappingAttributes).map(a => ({
+      return Object.keys(this.mappingAttributes)
+      .filter(a =>
+        this.mappingAttributes[a].type !== "text"
+      )
+      .map(a => ({
         text: a,
         value: a
       }))

--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -168,7 +168,7 @@
             placeholder="Attribute"
             :value="filters.sorting.attribute || ''"
             @change="attribute => setSortAttr(attribute)"
-            :options="selectAttributesValues"
+            :options="sortAttributesValues"
           >
             <template v-slot:first>
               <b-form-select-option :value="''" disabled
@@ -263,6 +263,12 @@ export default {
   computed: {
     ...mapGetters('kuzzle', ['wrapper']),
     selectAttributesValues() {
+      return Object.keys(this.mappingAttributes).map(a => ({
+        text: a,
+        value: a
+      }))
+    },
+    sortAttributesValues() {
       return Object.keys(this.mappingAttributes)
         .filter(a => this.mappingAttributes[a].type !== 'text')
         .map(a => ({

--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -264,13 +264,11 @@ export default {
     ...mapGetters('kuzzle', ['wrapper']),
     selectAttributesValues() {
       return Object.keys(this.mappingAttributes)
-      .filter(a =>
-        this.mappingAttributes[a].type !== "text"
-      )
-      .map(a => ({
-        text: a,
-        value: a
-      }))
+        .filter(a => this.mappingAttributes[a].type !== 'text')
+        .map(a => ({
+          text: a,
+          value: a
+        }))
     },
     availableOperandsFormatted() {
       return Object.keys(this.availableOperands).map(e => ({

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -147,7 +147,9 @@
                   />
 
                   <b-row
-                    v-show="totalDocuments > paginationSize && displayPagination"
+                    v-show="
+                      totalDocuments > paginationSize && displayPagination
+                    "
                     align-h="center"
                   >
                     <b-pagination
@@ -519,7 +521,7 @@ export default {
           this.indexName,
           this.collectionName
         )
-        this.displayPagination = true;
+        this.displayPagination = true
         this.loading = false
         await this.fetchDocuments()
       } catch (err) {
@@ -768,7 +770,7 @@ export default {
       this.formattedDocuments = formattedDocuments
     },
     changeDisplayPagination(value) {
-      this.displayPagination = value;
+      this.displayPagination = value
     }
   }
 }

--- a/src/components/Data/Documents/Views/TimeSeries.vue
+++ b/src/components/Data/Documents/Views/TimeSeries.vue
@@ -87,7 +87,8 @@
             No data to display
           </h2>
           <p>
-            You can only use chart view on collection that has mapping with fields of date and numeric fields...
+            You can only use chart view on collection that has mapping with
+            fields of date and numeric fields...
           </p>
         </b-card>
       </b-col>

--- a/src/services/mappingHelpers.ts
+++ b/src/services/mappingHelpers.ts
@@ -27,12 +27,14 @@ export const extractAttributesFromMapping = (
       }
       // Other attribute types are listed in the "fields" property
       if (value.fields) {
-        extractAttributesFromMapping(
-          value.properties,
-          attributes,
-          `${prefix}${name}.`,
-          path.concat(name, 'fields')
-        )
+        for(const type of Object.keys(value.fields))  {
+          extractAttributesFromMapping(
+            value.fields,
+            attributes,
+            `${prefix}${name}.`,
+            path.concat(name, '')
+          )
+        }
       }
     }
   }

--- a/test/e2e/cypress/integration/single-backend/search.spec.js
+++ b/test/e2e/cypress/integration/single-backend/search.spec.js
@@ -28,6 +28,9 @@ describe('Search', function() {
             }
           }
         },
+        fullName: {
+          type: 'text'
+        },
         lastName: {
           type: 'keyword',
           fields: {
@@ -897,5 +900,62 @@ describe('Search', function() {
     cy.get('[data-cy=Filters-fullscreen]').click({ force: true })
     cy.get('[data-cy=RawFilter-submitBtn]').click()
     cy.get('[data-cy="Filters"]').should('not.have.class', 'full-screen')
+  })
+
+  it('Should not be able to perform a Basic Search sort by a text field', function() {
+    cy.skipOnBackendVersion(1)
+    cy.request(
+      'POST',
+      `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
+      {
+        firstName: 'Adrien',
+        lastName: 'Maret',
+        job: 'Blockchain Keylogger as a Service',
+        fullName: 'Adrien Maret'
+      }
+    )
+
+    cy.visit('/')
+    cy.waitForLoading()
+
+    cy.get('.IndexesPage').should('be.visible')
+
+    cy.visit(`/#/data/${indexName}/${collectionName}`)
+    cy.waitForLoading()
+
+    cy.get('[data-cy="QuickFilter-optionBtn"]').click()
+    cy.get('[data-cy="Filters-basicTab"]').click()
+    cy.get('[data-cy="BasicFilter-sortAttributeSelect"]')
+      .get('[value="fullName"]')
+      .should('not', 'exists')
+  })
+
+  it('Should be able to perform a Basic Search sort by a text field with keyword as sub type', function() {
+    cy.skipOnBackendVersion(1)
+    cy.request(
+      'POST',
+      `${kuzzleUrl}/${indexName}/${collectionName}/_create?refresh=wait_for`,
+      {
+        firstName: 'Adrien',
+        lastName: 'Maret',
+        job: 'Blockchain Keylogger as a Service',
+        fullName: 'Adrien Maret'
+      }
+    )
+
+    cy.visit('/')
+    cy.waitForLoading()
+
+    cy.get('.IndexesPage').should('be.visible')
+
+    cy.visit(`/#/data/${indexName}/${collectionName}`)
+    cy.waitForLoading()
+
+    cy.get('[data-cy="QuickFilter-optionBtn"]').click()
+    cy.get('[data-cy="Filters-basicTab"]').click()
+    cy.get('[data-cy="BasicFilter-sortAttributeSelect"]')
+      .get('[value="lastName"]')
+    cy.get('[data-cy="BasicFilter-sortAttributeSelect"]')
+      .get('[value="lastName.keyword"]')
   })
 })


### PR DESCRIPTION
## What does this PR do ?
fix #852 

### How should this be manually tested?
1. `kourou index:create my-index`
2. `kourou collection:create my-index my-collection '{"age": { "type": "integer" },"name": { "type": "text" }}'`
3. `kourou document:create my-index my-collection '{"age":31, "name": "Nico"}'`
4. go to the admin console, and try perform an advanced search sorted by `name`, you can't

## Other changes
fix the extractAttributesFromMapping function, it was not extracting nested types from mapping

Now, if mapping contains a field like: 
```
firstName: {
          type: 'text',
          fielddata: true,
          fields: {
            keyword: {
              type: 'keyword',
              ignore_above: 256
            }
          }
        },
```
we will be able to select `firstName` or `firstName.keyword` in filters