### PR TITLE
838 fix displayed id

### DIFF
--- a/src/components/Data/Collections/DropdownView.vue
+++ b/src/components/Data/Collections/DropdownView.vue
@@ -28,6 +28,7 @@
         <b-dropdown-item
           data-cy="CollectionDropdown-TimeSeries"
           :active="activeView === 'time-series'"
+          :disabled="!mappingHasIntegerField"
           @click="$emit('time-series')"
         >
           Chart view
@@ -35,6 +36,7 @@
         <b-dropdown-item
           data-cy="CollectionDropdown-map"
           :active="activeView === 'map'"
+          :disabled="!mappingHasGeoField"
           @click="$emit('map')"
         >
           Map view
@@ -66,12 +68,23 @@ export default {
   name: 'CollectionDropdown',
   components: {},
   props: {
+    mappingAttributes: Object,
     activeView: String,
     collection: String,
     index: String
   },
   computed: {
-    ...mapGetters('auth', ['canSubscribe'])
+    ...mapGetters('auth', ['canSubscribe']),
+    mappingHasIntegerField() {
+      return Object.keys(this.mappingAttributes).filter(a =>
+        this.mappingAttributes[a].type === "integer"
+      ).length > 0
+    },
+    mappingHasGeoField() {
+      return Object.keys(this.mappingAttributes).filter(a =>
+        this.mappingAttributes[a].type === "geo_point"
+      ).length > 0
+    }
   }
 }
 </script>

--- a/src/components/Data/Collections/DropdownView.vue
+++ b/src/components/Data/Collections/DropdownView.vue
@@ -76,14 +76,18 @@ export default {
   computed: {
     ...mapGetters('auth', ['canSubscribe']),
     mappingHasIntegerField() {
-      return Object.keys(this.mappingAttributes).filter(a =>
-        this.mappingAttributes[a].type === "integer"
-      ).length > 0
+      return (
+        Object.keys(this.mappingAttributes).filter(
+          a => this.mappingAttributes[a].type === 'integer'
+        ).length > 0
+      )
     },
     mappingHasGeoField() {
-      return Object.keys(this.mappingAttributes).filter(a =>
-        this.mappingAttributes[a].type === "geo_point"
-      ).length > 0
+      return (
+        Object.keys(this.mappingAttributes).filter(
+          a => this.mappingAttributes[a].type === 'geo_point'
+        ).length > 0
+      )
     }
   }
 }

--- a/src/components/Data/Documents/Common/CreateOrUpdate.vue
+++ b/src/components/Data/Documents/Common/CreateOrUpdate.vue
@@ -202,7 +202,7 @@ export default {
         parsed = JSON.parse(val)
         this.$emit('document-change', parsed)
       } catch (error) {
-        // invalid json
+        // Fail silently
       }
     },
     onFormChange() {

--- a/src/components/Data/Documents/Common/CreateOrUpdate.vue
+++ b/src/components/Data/Documents/Common/CreateOrUpdate.vue
@@ -93,6 +93,7 @@
             data-cy="DocumentCreate-btn"
             variant="primary"
             class="ml-2"
+            :disabled="submitting || !isDocumentValid"
             @click="submit"
           >
             <i class="fa fa-plus-circle left" />
@@ -196,7 +197,13 @@ export default {
   methods: {
     onJsonChange(val) {
       this.rawDocument = val
-      this.$emit('document-change', JSON.parse(val))
+      let parsed = {}
+      try {
+        parsed = JSON.parse(val)
+        this.$emit('document-change', parsed)
+      } catch (error) {
+        // invalid json
+      }
     },
     onFormChange() {
       this.rawDocument = JSON.stringify(this.document, null, 2)

--- a/src/components/Data/Documents/DocumentListItem.vue
+++ b/src/components/Data/Documents/DocumentListItem.vue
@@ -23,7 +23,7 @@
         <a
           class="d-inline-block align-middle code pointer"
           @click="toggleCollapse"
-          >{{ document.id }}</a
+          >{{ document._id }}</a
         >
       </b-col>
       <b-col cols="2">
@@ -32,7 +32,7 @@
             class="DocumentListItem-update"
             href=""
             variant="link"
-            :data-cy="`DocumentListItem-update--${document.id}`"
+            :data-cy="`DocumentListItem-update--${document._id}`"
             :disabled="!canEdit"
             :title="
               canEdit
@@ -47,7 +47,7 @@
             class="DocumentListItem-delete"
             href=""
             variant="link"
-            :data-cy="`DocumentListItem-delete--${document.id}`"
+            :data-cy="`DocumentListItem-delete--${document._id}`"
             :disabled="!canDelete"
             :title="
               canDelete
@@ -63,7 +63,7 @@
     </b-row>
     <b-row>
       <b-collapse
-        :id="`collapse-${document.id}`"
+        :id="`collapse-${document._id}`"
         v-model="expanded"
         class="ml-3 DocumentListItem-content w-100"
       >
@@ -117,14 +117,14 @@ export default {
       return this.canDeleteDocument(this.index, this.collection)
     },
     checkboxId() {
-      return `checkbox-${this.document.id}`
+      return `checkbox-${this.document._id}`
     },
     /**
      * Deletes the "id" who should not be displayed in the document body.
      * Also put the "_kuzzle_info" field in last position
      */
     formattedDocument() {
-      const document = _.omit(this.document, ['id', '_kuzzle_info'])
+      const document = _.omit(this.document, ['_id', '_kuzzle_info'])
       document._kuzzle_info = this.document._kuzzle_info
       return document
     }
@@ -134,18 +134,18 @@ export default {
       this.expanded = !this.expanded
     },
     notifyCheckboxClick() {
-      this.$emit('checkbox-click', this.document.id)
+      this.$emit('checkbox-click', this.document._id)
     },
     deleteDocument() {
       if (this.canDelete) {
-        this.$emit('delete', this.document.id)
+        this.$emit('delete', this.document._id)
       }
     },
     editDocument() {
       if (this.canEdit) {
         this.$router.push({
           name: 'UpdateDocument',
-          params: { id: this.document.id }
+          params: { id: this.document._id }
         })
       }
     }

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -31,6 +31,7 @@
             :active-view="listViewType"
             :index="indexName"
             :collection="collectionName"
+            :mappingAttributes="mappingAttributes"
             @list="onListViewClicked"
             @map="onMapViewClicked"
             @column="onColumnViewClicked"
@@ -100,7 +101,7 @@
                     @delete="onDeleteClicked"
                     @refresh="onRefresh"
                     @toggle-all="onToggleAllClicked"
-                  ></List>
+                  />
 
                   <Column
                     v-if="listViewType === 'column'"
@@ -120,6 +121,7 @@
                     @refresh="onRefresh"
                     @toggle-all="onToggleAllClicked"
                   />
+
                   <TimeSeries
                     v-if="listViewType === 'time-series'"
                     :index="indexName"
@@ -541,7 +543,7 @@ export default {
 
       this.$router.push({
         name: 'UpdateDocument',
-        params: { id: document.id }
+        params: { id: document._id }
       })
     },
     onRefresh() {
@@ -657,7 +659,7 @@ export default {
         return
       }
       this.selectedDocuments = []
-      this.selectedDocuments = this.documents.map(document => document.id)
+      this.selectedDocuments = this.documents.map(document => document._id)
     },
     toggleSelectDocuments(id) {
       let index = this.selectedDocuments.indexOf(id)
@@ -737,7 +739,7 @@ export default {
 
       const dateFields = []
       const formattedDocuments = _.cloneDeep(this.documents)
-
+      console.log(this.documents);
       const findDateFields = (mapping, previousKey) => {
         for (const [field, value] of Object.entries(mapping)) {
           if (typeof value === 'object') {

--- a/src/components/Data/Documents/Page.vue
+++ b/src/components/Data/Documents/Page.vue
@@ -149,7 +149,9 @@
                   />
 
                   <b-row
-                    v-show="totalDocuments > paginationSize && displayPagination"
+                    v-show="
+                      totalDocuments > paginationSize && displayPagination
+                    "
                     align-h="center"
                   >
                     <b-pagination
@@ -521,7 +523,7 @@ export default {
           this.indexName,
           this.collectionName
         )
-        this.displayPagination = true;
+        this.displayPagination = true
         this.loading = false
         await this.fetchDocuments()
       } catch (err) {
@@ -739,7 +741,6 @@ export default {
 
       const dateFields = []
       const formattedDocuments = _.cloneDeep(this.documents)
-      console.log(this.documents);
       const findDateFields = (mapping, previousKey) => {
         for (const [field, value] of Object.entries(mapping)) {
           if (typeof value === 'object') {
@@ -770,7 +771,7 @@ export default {
       this.formattedDocuments = formattedDocuments
     },
     changeDisplayPagination(value) {
-      this.displayPagination = value;
+      this.displayPagination = value
     }
   }
 }

--- a/src/components/Data/Documents/Views/Column.vue
+++ b/src/components/Data/Documents/Views/Column.vue
@@ -119,21 +119,21 @@
             </b-tr>
           </b-thead>
           <b-tbody>
-            <b-tr v-for="item of formattedItems" :key="`item-row-${item.id}`">
+            <b-tr v-for="item of formattedItems" :key="`item-row-${item._id}`">
               <b-td
                 class="cell"
                 colspan="1"
                 v-for="field of tableDefaultHeaders"
                 :key="`item-col-${field.key}`"
-                :id="`col-${item.id}-${field}`"
+                :id="`col-${item._id}-${field}`"
               >
                 <template v-if="field.key === 'acColumnTableActions'">
                   <div class="inlineDisplay">
                     <span class="inlineDisplay-item">
                       <b-form-checkbox
-                        :checked="isChecked(item.id)"
-                        :data-cy="`ColumnView-table-select-btn--${item.id}`"
-                        @change="toggleSelectDocument(item.id)"
+                        :checked="isChecked(item._id)"
+                        :data-cy="`ColumnView-table-select-btn--${item._id}`"
+                        @change="toggleSelectDocument(item._id)"
                       />
                     </span>
                     <span class="inlineDisplay-item">
@@ -141,9 +141,9 @@
                         title="Edit document"
                         variant="link"
                         class="px-0 mx-1"
-                        :data-cy="`ColumnView-table-edit-btn--${item.id}`"
+                        :data-cy="`ColumnView-table-edit-btn--${item._id}`"
                         :disabled="!canEdit"
-                        @click="editDocument(item.id)"
+                        @click="editDocument(item._id)"
                       >
                         <i class="fa fa-pen" />
                       </b-button>
@@ -153,9 +153,9 @@
                         class="px-0 mx-1"
                         title="Delete document"
                         variant="link"
-                        :data-cy="`ColumnView-table-delete-btn--${item.id}`"
+                        :data-cy="`ColumnView-table-delete-btn--${item._id}`"
                         :disabled="!canDelete"
-                        @click="deleteDocument(item.id)"
+                        @click="deleteDocument(item._id)"
                       >
                         <i class="fa fa-trash" />
                       </b-button>
@@ -163,7 +163,7 @@
                   </div>
                 </template>
                 <template v-else-if="field.key === 'acColumnTableId'">
-                  {{ item.id }}
+                  {{ item._id }}
                 </template>
               </b-td>
             </b-tr>
@@ -202,7 +202,7 @@
                 class="cell"
                 v-for="field of selectedFields"
                 :key="`item-col-${field}`"
-                :id="`col-${item.id}-${field}`"
+                :id="`col-${item._id}-${field}`"
               >
                 {{ item[field] }}
               </b-td>
@@ -282,7 +282,7 @@ export default {
     formattedItems() {
       return this.documents.map(d => {
         const doc = {}
-        doc.id = d.id
+        doc._id = d._id
         for (const key of this.selectedFields) {
           // if there is an array in the current document within the 'path'
           if (this.documentPathContainsArray(key, d)) {
@@ -314,7 +314,7 @@ export default {
       return this.canDeleteDocument(this.index, this.collection)
     },
     checkboxId() {
-      return `checkbox-${this.document.id}`
+      return `checkbox-${this.document._id}`
     }
   },
   methods: {

--- a/src/components/Data/Documents/Views/List.vue
+++ b/src/components/Data/Documents/Views/List.vue
@@ -52,13 +52,13 @@
         v-for="document in documents"
         class="p-2"
         data-cy="DocumentList-item"
-        :key="document.id"
+        :key="document._id"
       >
         <document-list-item
           :document="document"
           :collection="collection"
           :index="index"
-          :is-checked="isChecked(document.id)"
+          :is-checked="isChecked(document._id)"
           @checkbox-click="$emit('checkbox-click', $event)"
           @delete="$emit('delete', $event)"
         />

--- a/src/components/Data/Documents/Views/Map.vue
+++ b/src/components/Data/Documents/Views/Map.vue
@@ -33,7 +33,7 @@
           <l-tile-layer :url="url" :attribution="attribution" />
           <l-marker
             v-for="document in geoDocuments"
-            :key="document.source.id"
+            :key="document.source._id"
             :lat-lng="document.coordinates"
             :icon="getIcon(document.source)"
             @click="onMarkerClick(document.source)"
@@ -50,7 +50,7 @@
             <b-row align-v="center">
               <b-col cols="9" align-v="center">
                 <span data-cy="mapView-current-document-id">{{
-                  currentDocument.id
+                  currentDocument._id
                 }}</span>
               </b-col>
               <b-col cols="3">
@@ -58,7 +58,7 @@
                   class="DocumentMapItem-update"
                   href=""
                   variant="link"
-                  :data-cy="`DocumentMapItem-update--${currentDocument.id}`"
+                  :data-cy="`DocumentMapItem-update--${currentDocument._id}`"
                   :disabled="!canEdit"
                   :title="
                     canEdit
@@ -74,7 +74,7 @@
                   class="DocumentListItem-delete"
                   href=""
                   variant="link"
-                  :data-cy="`DocumentListItem-delete--${currentDocument.id}`"
+                  :data-cy="`DocumentListItem-delete--${currentDocument._id}`"
                   :disabled="!canDelete"
                   :title="
                     canDelete
@@ -241,7 +241,7 @@ export default {
       if (!this.currentDocument) {
         return {}
       }
-      const document = _.omit(this.currentDocument, ['id', '_kuzzle_info'])
+      const document = _.omit(this.currentDocument, ['_id', '_kuzzle_info'])
       document._kuzzle_info = this.currentDocument._kuzzle_info
       return document
     }
@@ -273,22 +273,22 @@ export default {
     getIcon(document) {
       if (this.currentDocument === document) {
         return new this.LeafSelectedIcon({
-          className: `mapView-marker-selected documentId-${document.id}`
+          className: `mapView-marker-selected documentId-${document._id}`
         })
       }
 
       return new this.LeafDefaultIcon({
-        className: `mapView-marker-default documentId-${document.id}`
+        className: `mapView-marker-default documentId-${document._id}`
       })
     },
     deleteCurrentDocument() {
       if (this.canDelete) {
-        this.$emit('delete', this.currentDocument.id)
+        this.$emit('delete', this.currentDocument._id)
       }
     },
     editCurrentDocument() {
       if (this.canEdit) {
-        this.$emit('edit', this.currentDocument.id)
+        this.$emit('edit', this.currentDocument._id)
       }
     }
   }

--- a/src/components/Data/Documents/Views/TimeSeries.vue
+++ b/src/components/Data/Documents/Views/TimeSeries.vue
@@ -87,7 +87,8 @@
             No data to display
           </h2>
           <p>
-            You can only use chart view on collection that has mapping with fields of date and numeric fields...
+            You can only use chart view on collection that has mapping with
+            fields of date and numeric fields...
           </p>
         </b-card>
       </b-col>

--- a/src/services/kuzzleWrapper-v1.ts
+++ b/src/services/kuzzleWrapper-v1.ts
@@ -375,7 +375,7 @@ export class KuzzleWrapperV1 {
     )
 
     const documents = result.hits.map(d => ({
-      id: d._id,
+      _id: d._id,
       ...d._source,
       _kuzzle_info: d._source._kuzzle_info
         ? this.formatMeta(d._source._kuzzle_info)

--- a/test/e2e/cypress/integration/single-backend/docs.spec.js
+++ b/test/e2e/cypress/integration/single-backend/docs.spec.js
@@ -47,7 +47,7 @@ describe('Document List', function() {
     cy.get('[data-cy="DocumentList-item"]').should('exist')
   })
 
-  it.only('Should show the the _id even if collection has id field', function() {
+  it('Should show the the _id even if collection has id field', function() {
     cy.request(
       'POST',
       `${kuzzleUrl}/${indexName}/${collectionName}/documentId/_create?refresh=wait_for`,

--- a/test/e2e/cypress/integration/single-backend/docs.spec.js
+++ b/test/e2e/cypress/integration/single-backend/docs.spec.js
@@ -17,6 +17,9 @@ describe('Document List', function() {
         },
         value2: {
           type: 'integer'
+        },
+        id: {
+          type: 'keyword'
         }
       }
     })
@@ -26,7 +29,8 @@ describe('Document List', function() {
       {
         firstName: 'Luca',
         lastName: 'Marchesini',
-        job: 'Blockchain as a Service'
+        job: 'Blockchain as a Service',
+        id: 'Luca Marchesini'
       }
     )
 
@@ -42,6 +46,26 @@ describe('Document List', function() {
     cy.visit(`/#/data/${indexName}/${collectionName}`)
     cy.get('[data-cy="DocumentList-item"]').should('exist')
   })
+
+  it.only('Should show the the _id even if collection has id field', function() {
+    cy.request(
+      'POST',
+      `${kuzzleUrl}/${indexName}/${collectionName}/documentId/_create?refresh=wait_for`,
+      {
+        firstName: 'Luca',
+        lastName: 'Marchesini',
+        job: 'Blockchain as a Service',
+        id: 'Luca Marchesini'
+      }
+    )
+    cy.visit(`/#/data/${indexName}/${collectionName}`)
+    cy.get('[data-cy="DocumentList-item"]')
+    .within(() => {
+      cy.get("a").contains("documentId")
+      cy.get("a").not().contains('Luca Marchesini')
+    })
+  })
+
 
   it('Should be able to set and persist the listViewType param when switching the list view', function() {
     cy.waitOverlay()


### PR DESCRIPTION
## What does this PR do ?
fix #838 

### How should this be manually tested?
  - Step 1 : create a collection with field `id` in mapping
  - Step 2 : create a document with a value in `id` field
  - Step 3 : check on document views (list/column/map...), the _id is now  displayed
  ...

### Other changes
disable map view when mapping have no `geo_point` field
disable chart view when mapping have no `integer` field

### Boyscout
catch json editor error (browser console was spammed when creating/editing documents)
