### PR TITLE
fix ci 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,8 +9,8 @@ module.exports = {
   extends: ["plugin:vue/essential", "@vue/prettier", '@vue/typescript'],
 
   rules: {
-    "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
-    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
+    "no-console": "error",
+    "no-debugger": "error",
     "require-atomic-updates": "off"
   },
 

--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -338,7 +338,6 @@ export default {
       this.$emit('generate-raw-filter', raw)
     },
     submitSearch() {
-      console.log("test lint ci")
       if (!this.isFilterValid) {
         return
       }

--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -162,13 +162,6 @@
 
     <b-row align-h="center" align-v="center">
       <b-col md="4">
-
-
-
-
-
-
-
         <b-input-group v-if="sortingEnabled" class="ml-1" prepend="Sort">
           <b-form-select
             data-cy="BasicFilter-sortAttributeSelect"
@@ -345,7 +338,6 @@ export default {
       this.$emit('generate-raw-filter', raw)
     },
     submitSearch() {
-      console.log("test ci !")
       if (!this.isFilterValid) {
         return
       }

--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -162,6 +162,13 @@
 
     <b-row align-h="center" align-v="center">
       <b-col md="4">
+
+
+
+
+
+
+
         <b-input-group v-if="sortingEnabled" class="ml-1" prepend="Sort">
           <b-form-select
             data-cy="BasicFilter-sortAttributeSelect"

--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -338,6 +338,7 @@ export default {
       this.$emit('generate-raw-filter', raw)
     },
     submitSearch() {
+      console.log("test lint ci")
       if (!this.isFilterValid) {
         return
       }

--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -345,6 +345,7 @@ export default {
       this.$emit('generate-raw-filter', raw)
     },
     submitSearch() {
+      console.log("test ci !")
       if (!this.isFilterValid) {
         return
       }


### PR DESCRIPTION
Ci have no build step
Ci lint doesn't failed if `console.log` is present because of the `prodution` rule
Netlify build fail if `console` statement is present

Remove the `production` rule to let linter fail if `console` statement is present
