### PR TITLE
809 remove strategy with no credentials

### DIFF
--- a/src/components/Security/Users/CreateOrUpdate.vue
+++ b/src/components/Security/Users/CreateOrUpdate.vue
@@ -185,12 +185,7 @@ export default {
       this.$v.kuid.$model = value
     },
     onCredentialsChanged(payload) {
-      const notEmptyFields = Object.keys(payload.credentials).filter(c => payload.credentials[c] !== "").length > 0
-      if (notEmptyFields) {
-        this.credentials[payload.strategy] = { ...payload.credentials }
-      } else {
-        delete this.credentials[payload.strategy]
-      }
+      this.credentials[payload.strategy] = { ...payload.credentials }
     },
     onCustomContentChanged(value) {
       this.$v.customContentValue.$model = value
@@ -205,6 +200,15 @@ export default {
       this.$v.$touch()
       if (this.$v.$anyError) {
         return
+      }
+      for (const strategy of Object.keys(this.credentials)) {
+        const credentials = this.credentials[strategy]
+        const notEmptyFields = Object.keys(credentials).filter(
+          field => credentials[field] !== ''
+        )
+        if (notEmptyFields.length === 0) {
+          delete this.credentials[strategy]
+        }
       }
       this.submitting = true
       try {

--- a/src/components/Security/Users/CreateOrUpdate.vue
+++ b/src/components/Security/Users/CreateOrUpdate.vue
@@ -185,7 +185,12 @@ export default {
       this.$v.kuid.$model = value
     },
     onCredentialsChanged(payload) {
-      this.credentials[payload.strategy] = { ...payload.credentials }
+      const notEmptyFields = Object.keys(payload.credentials).filter(c => payload.credentials[c] !== "").length > 0
+      if (notEmptyFields) {
+        this.credentials[payload.strategy] = { ...payload.credentials }
+      } else {
+        delete this.credentials[payload.strategy]
+      }
     },
     onCustomContentChanged(value) {
       this.$v.customContentValue.$model = value
@@ -202,7 +207,6 @@ export default {
         return
       }
       this.submitting = true
-
       try {
         if (this.id) {
           await this.wrapper.performReplaceUser(this.kuid, {

--- a/src/components/Security/Users/Steps/Basic.vue
+++ b/src/components/Security/Users/Steps/Basic.vue
@@ -12,7 +12,6 @@
         >
       </template>
       <b-input
-        v-if="editKuid"
         class="validate"
         id="custom-kuid"
         placeholder="You can leave this field empty to let Kuzzle auto-generate the KUID"

--- a/test/e2e/cypress/integration/single-backend/users.spec.js
+++ b/test/e2e/cypress/integration/single-backend/users.spec.js
@@ -345,7 +345,6 @@ describe('Users', function() {
       expect(location.hash).to.equal(`#/security/users/create`)
     })
   })
-
   it('Should be able to list the users with a wrong from url parameter', () => {
     cy.skipOnBackendVersion(1)
     for (let i = 0; i < 5; i++) {

--- a/test/e2e/cypress/integration/single-backend/users.spec.js
+++ b/test/e2e/cypress/integration/single-backend/users.spec.js
@@ -345,7 +345,7 @@ describe('Users', function() {
       expect(location.hash).to.equal(`#/security/users/create`)
     })
   })
-  
+
   it('Should be able to list the users with a wrong from url parameter', () => {
     cy.skipOnBackendVersion(1)
     for (let i = 0; i < 5; i++) {
@@ -581,5 +581,19 @@ describe('Users', function() {
     profileIds.forEach(profileId => {
       cy.contains(profileId)
     })
+  })
+
+  it.only('Should be able to create an user without strategy', () => {
+    cy.visit(`/#/security/users/create`)
+
+    cy.get('[data-cy=UserBasic-kuid]').type("without-credentials")
+    cy.get('[data-cy="UserProfileList-select"]').select('admin')
+    cy.get('[data-cy=CredentialsSelector-local-username]').clear()
+    cy.get('[data-cy=CredentialsSelector-local-password]').clear()
+    cy.get('[data-cy="UserUpdate-submit"]').click({ force: true })
+    cy.get('[id="collapse-without-credentials"]')
+    .contains("local:")
+    .next()
+    .should("have.class", "json-formatter-empty")
   })
 })

--- a/test/e2e/cypress/integration/single-backend/users.spec.js
+++ b/test/e2e/cypress/integration/single-backend/users.spec.js
@@ -582,7 +582,7 @@ describe('Users', function() {
     })
   })
 
-  it.only('Should be able to create an user without strategy', () => {
+  it('Should be able to create an user without strategy', () => {
     cy.visit(`/#/security/users/create`)
 
     cy.get('[data-cy=UserBasic-kuid]').type("without-credentials")


### PR DESCRIPTION
## What does this PR do ?
fix #809 

Before: Create an user with blank username/password for local strategy -> create an user with empty string as credentials
Now: Create an user with blank username/password for local strategy -> just remove strategy from credentials during user creation

UI/UX of that card should be adapted -> #874 

### How should this be manually tested?
  - Step 1 : Go to security/users
  - Step 2 : play with the strategy credentials during user creation
  - Step 3 : Should be able to create user without credentials

### Other changes
display kuid when editing user
