### PR TITLE
[navbar] Added github icon

### DIFF
--- a/src/components/Common/MainMenu.vue
+++ b/src/components/Common/MainMenu.vue
@@ -35,6 +35,16 @@
         >
           Security
         </b-nav-item>
+        <b-nav-text
+          class="ml-2"
+          title="Give us your feedback on our GitHub page"
+        >
+          <a
+            href="https://github.com/kuzzleio/kuzzle-admin-console"
+            target="_blank"
+            ><i class="logout fab fa-github fa-lg"
+          /></a>
+        </b-nav-text>
       </b-navbar-nav>
       <b-navbar-nav class="ml-auto">
         <b-nav-text


### PR DESCRIPTION
Adds a little GitHub icon with a tooltip to indicate the users they can give their feedback on out GH repo.
![image](https://user-images.githubusercontent.com/5023426/106639054-d8a96280-6584-11eb-9f4c-df1da0f40dd9.png)

