### PR TITLE
Better tests cli and cypress tag

### DIFF
--- a/.github/actions/e2e-tests/action.yml
+++ b/.github/actions/e2e-tests/action.yml
@@ -6,7 +6,10 @@ inputs:
     description: Kuzzle setup configuration (1 or 2 or multi)
     required: true
   CYPRESS_RECORD_KEY:
-    description: Kuzzle setup configuration (1 or 2 or multi)
+    description: Cypress token to record the tests on cypress dashboard
+    required: true
+  branch_name:
+    description: Name of the branch to add a tag on cypress dashboard
     required: true
 
 runs:
@@ -16,7 +19,7 @@ runs:
       shell: bash
     - run: cd test/e2e/run-test && npm ci && cd -
       shell: bash
-    - run: npm run test:e2e -- --backend=${{ inputs.backend_config}}
+    - run: npm run test:e2e -- --backend=${{ inputs.backend_config}} --tag ${{ inputs.branch_name }}
       env:
         CYPRESS_RECORD_KEY: ${{ inputs.CYPRESS_RECORD_KEY }}
       shell: bash

--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -56,4 +56,5 @@ jobs:
         with:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           backend_config: ${{ matrix.backend_config }}
+          branch_name: ${{ github.head_ref }}
 

--- a/.github/workflows/push_dev.workflow.yml
+++ b/.github/workflows/push_dev.workflow.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           backend_config: ${{ matrix.backend_config }}
+          branch_name: ${GITHUB_REF##*/}
 
   deploy-staging:
     name: Deploy Admin Console to staging - next-console.kuzzle.io

--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           backend_config: ${{ matrix.backend_config }}
+          branch_name: ${GITHUB_REF##*/}
 
   deploy-production:
     name: Deploy Admin Console to production - console.kuzzle.io

--- a/test/e2e/run-test/src/index.ts
+++ b/test/e2e/run-test/src/index.ts
@@ -36,12 +36,12 @@ class RunTest extends Command {
         break
       case 'multi':
       default:
-        await this.multiBackend(flags.local, flags.tag)
+        await this.multiBackend(flags.local, flags.spec, flags.tag)
         break
     }
   }
 
-  async singleBackend(backend: string, local: boolean = false, specs: String[], tags: String[]) {
+  async singleBackend(backend: string, local: boolean = false, spec: String[], tag: String[]) {
     this.log(
       chalk.blueBright(
         ` Preparing single-backend stack with Kuzzle v${backend}`
@@ -113,8 +113,8 @@ class RunTest extends Command {
       backend,
       process.env.CYPRESS_RECORD_KEY,
       false,
-      specs,
-      tags
+      spec,
+      tag
     )
     this.log(npmArgs.join())
     try {
@@ -134,7 +134,7 @@ class RunTest extends Command {
     }
   }
 
-  async multiBackend(local: boolean = false, tags: String[]) {
+  async multiBackend(local: boolean = false, spec: String[], tag: String[]) {
     this.log(chalk.blueBright(` Preparing multi-backend stack`))
 
     const tasks = new Listr([
@@ -165,8 +165,8 @@ class RunTest extends Command {
       'multi-backend',
       process.env.CYPRESS_RECORD_KEY,
       true,
-      [],
-      tags
+      spec,
+      tag
     )
     try {
       const cy = execa('cypress', npmArgs, {
@@ -224,13 +224,11 @@ class RunTest extends Command {
       }
     }
     let specsArg = ''
-    if (specs.length !== 0 && backend !== 'multi-backend') {
-      specsArg = specs.map(s => `test/e2e/cypress/integration/single-backend/${s}.spec.js`).join()
+    const basePath = `test/e2e/cypress/integration/${multi ? 'multi-backend' : 'single-backend'}/`
+    if (specs.length !== 0) {
+      specsArg = specs.map(s => `${basePath}${s}.spec.js`).join()
     } else {
-      specsArg =
-        `test/e2e/cypress/integration/${
-          multi ? 'multi-backend' : 'single-backend'
-        }/*.spec.js`
+      specsArg = `${basePath}*.spec.js`
     }
     cypressArgs.push("--spec")
     cypressArgs.push(specsArg)


### PR DESCRIPTION
## What does this PR do ?
Improve the `run-test` cli to:
  - allow add cypress tags
         `npm run tests:e2e -- --tag [tag1] --tag [tag2]` 
          default no tags
  - run only some spec instead of all
         `npm run test:e2e -- --spec [specFileName]`
          alias `-s`
          default all specs
 
### How should this be manually tested?
  - Step 1 : tags are tested directly in ci, just go to [cypress dashboard](https://dashboard.cypress.io/projects/qnb41a/runs) and check latests runs of the admin console (it should have a tag with the name of the current branch)
  - Step 2 : try run  `npm run test:e2e -- -s collections -s environments` only the collections and environments tests should run


### Other changes
/

### Boyscout
/

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/44427849/106868776-7f9a1580-66cf-11eb-92bc-dc0ead4cf4c0.png)

