### PR TITLE
Display local strategy usernames if found

### DIFF
--- a/src/components/Security/Users/UserItem.vue
+++ b/src/components/Security/Users/UserItem.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <b-container fluid data-cy="UserItem" class="UserItem">
+  <div data-cy="UserItem" class="UserItem">
+    <b-container fluid class="UserItem-container">
       <div class="UserItem-toggle-select mr-3">
         <i
           aria-role="button"
@@ -178,9 +178,11 @@ export default {
 
 <style lang="scss" rel="stylesheet/scss" scoped>
 .UserItem {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
+  &-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
 
   &-toggle-select {
     display: flex;

--- a/src/components/Security/Users/UserItem.vue
+++ b/src/components/Security/Users/UserItem.vue
@@ -25,7 +25,7 @@
         <a
           class="d-inline-block align-middle code pointer mr-2"
           @click="toggleCollapse"
-          >{{ document.id }}</a
+          >{{ userDisplayedId }}</a
         >
         <div class="UserItem-profileList">
           <b-badge
@@ -136,6 +136,12 @@ export default {
     },
     checkboxId() {
       return `checkbox-${this.document.id}`
+    },
+    userDisplayedId() {
+      if (this.document.credentials && this.document.credentials.local) {
+        return `${this.document.credentials.local.username}`
+      }
+      return `${this.document.id}`
     }
   },
   watch: {

--- a/src/components/Security/Users/UserItem.vue
+++ b/src/components/Security/Users/UserItem.vue
@@ -1,19 +1,14 @@
 <template>
-  <b-container fluid data-cy="UserItem">
-    <b-row align-h="between" no-gutters>
-      <b-col cols="12" class="UserItem-titleCol py-1 vertical-align">
+  <div>
+    <b-container fluid data-cy="UserItem" class="UserItem">
+      <div class="UserItem-toggle-select mr-3">
         <i
           aria-role="button"
-          :class="
-            `fa fa-caret-${
-              expanded ? 'down' : 'right'
-            } mr-2  d-inline-block align-middle`
-          "
+          :class="`fa fa-caret-${expanded ? 'down' : 'right'} mr-2 `"
           :data-cy="`UserItem-${document.id}--toggle`"
           @click="toggleCollapse"
         />
         <b-form-checkbox
-          class="d-inline-block align-middle"
           type="checkbox"
           value="true"
           unchecked-value="false"
@@ -22,16 +17,40 @@
           :id="checkboxId"
           @change="notifyCheckboxClick"
         />
-        <a
-          class="d-inline-block align-middle code pointer mr-2"
-          @click="toggleCollapse"
-          >{{ userDisplayedId }}</a
-        >
-        <div class="UserItem-profileList">
+      </div>
+      <div class="UserItem-title">
+        <div class="UserItem-title-info">
+          <a
+            class="d-inline-block align-middle code pointer mr-2"
+            @click="toggleCollapse"
+            >{{ document.id }}</a
+          >
+          <span
+            v-if="localStrategyUsername"
+            :data-cy="`local-strategy-username-${localStrategyUsername}`"
+            class="d-inline-block align-middle code ml-2 mr-2"
+          >
+            <i
+              class="fas fa-user text-secondary"
+              title="Username (local strategy)"
+            />
+            {{ localStrategyUsername }}
+          </span>
+          <label
+            @click="toggleCollapse"
+            v-if="
+              document.additionalAttribute && document.additionalAttribute.value
+            "
+            class="UserItem-title-additionalAttribute"
+            >({{ document.additionalAttribute.name }}:
+            {{ document.additionalAttribute.value }})</label
+          >
+        </div>
+        <div class="UserItem-title-profiles">
           <b-badge
             v-for="profile in profileList"
             :key="profile"
-            class="ml-1"
+            class="mr-1 mt-1 mb-1"
             variant="primary"
           >
             <router-link
@@ -43,61 +62,47 @@
               >{{ profile }}</router-link
             >
           </b-badge>
-          <div class="UserItem-whiteGradient"></div>
         </div>
-        <label
-          @click="toggleCollapse"
-          v-if="
-            document.additionalAttribute && document.additionalAttribute.value
+      </div>
+      <div class="UserItem-actions">
+        <b-button
+          class="UserListItem-update"
+          href=""
+          variant="link"
+          :data-cy="`UserListItem-update--${document.id}`"
+          :disabled="!canEditUser"
+          :title="
+            canEditUser ? 'Edit User' : 'You are not allowed to edit this user'
           "
-          class="UserItem-additionalAttribute"
-          >({{ document.additionalAttribute.name }}:
-          {{ document.additionalAttribute.value }})</label
+          @click.prevent="update"
         >
-        <div class="UserItem-actions">
-          <b-button
-            class="UserListItem-update"
-            href=""
-            variant="link"
-            :data-cy="`UserListItem-update--${document.id}`"
-            :disabled="!canEditUser"
-            :title="
-              canEditUser
-                ? 'Edit User'
-                : 'You are not allowed to edit this user'
-            "
-            @click.prevent="update"
-          >
-            <i class="fa fa-pencil-alt" :class="{ disabled: !canEditUser }" />
-          </b-button>
-          <b-button
-            class="UserListItem-delete"
-            href=""
-            variant="link"
-            :data-cy="`UserListItem-delete--${document.id}`"
-            :disabled="!canDeleteUser"
-            :title="
-              canDeleteUser
-                ? 'Delete user'
-                : 'You are not allowed to delete this user'
-            "
-            @click.prevent="deleteDocument(document.id)"
-          >
-            <i class="fa fa-trash" :class="{ disabled: !canDeleteUser }" />
-          </b-button>
-        </div>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-collapse
-        :id="`collapse-${document.id}`"
-        v-model="expanded"
-        class="ml-3 DocumentListItem-content"
-      >
-        <pre v-json-formatter="{ content: document, open: true }" />
-      </b-collapse>
-    </b-row>
-  </b-container>
+          <i class="fa fa-pencil-alt" :class="{ disabled: !canEditUser }" />
+        </b-button>
+        <b-button
+          class="UserListItem-delete"
+          href=""
+          variant="link"
+          :data-cy="`UserListItem-delete--${document.id}`"
+          :disabled="!canDeleteUser"
+          :title="
+            canDeleteUser
+              ? 'Delete user'
+              : 'You are not allowed to delete this user'
+          "
+          @click.prevent="deleteDocument(document.id)"
+        >
+          <i class="fa fa-trash" :class="{ disabled: !canDeleteUser }" />
+        </b-button>
+      </div>
+    </b-container>
+    <b-collapse
+      :id="`collapse-${document.id}`"
+      v-model="expanded"
+      class="ml-3 DocumentListItem-content"
+    >
+      <pre v-json-formatter="{ content: document, open: true }" />
+    </b-collapse>
+  </div>
 </template>
 
 <script>
@@ -137,11 +142,10 @@ export default {
     checkboxId() {
       return `checkbox-${this.document.id}`
     },
-    userDisplayedId() {
-      if (this.document.credentials && this.document.credentials.local) {
-        return `${this.document.credentials.local.username}`
-      }
-      return `${this.document.id}`
+    localStrategyUsername() {
+      return this.document.credentials && this.document.credentials.local
+        ? this.document.credentials.local.username
+        : null
     }
   },
   watch: {
@@ -173,45 +177,37 @@ export default {
 </script>
 
 <style lang="scss" rel="stylesheet/scss" scoped>
-.UserItem-titleCol {
+.UserItem {
   display: flex;
-}
+  flex-direction: row;
+  align-items: center;
 
-.UserItem-actions {
-  white-space: nowrap;
-}
+  &-toggle-select {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+  }
 
-.UserItem-additionalAttribute {
-  color: grey;
-  font-style: italic;
-  color: black;
-  line-height: 21px;
-}
+  &-actions {
+    display: flex;
+    flex-wrap: nowrap;
+  }
 
-.UserItem-profileList {
-  display: inline-block;
-  overflow-x: hidden;
-  flex-grow: 1;
-  white-space: nowrap;
-  position: relative;
-}
+  &-title {
+    flex-grow: 1;
 
-.UserItem-whiteGradient {
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: 50px;
-  height: 100%;
-  background: linear-gradient(
-    to right,
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 0.65) 50%,
-    rgba(255, 255, 255, 1) 100%
-  );
-}
+    &-profiles {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
 
-.UserItem-actions {
-  margin-top: 1px;
-  font-size: 1em;
+    &-additionalAttribute {
+      color: grey;
+      font-style: italic;
+      color: black;
+      line-height: 21px;
+    }
+  }
 }
 </style>

--- a/test/e2e/cypress/integration/single-backend/users.spec.js
+++ b/test/e2e/cypress/integration/single-backend/users.spec.js
@@ -625,18 +625,40 @@ describe('Users', function() {
     })
   })
 
+  it('Should display the username if it is present in the local strategy', () => {
+    const username = 'Estebaaaan'
+
+    cy.request('POST', `${kuzzleUrl}/users/_create?refresh=wait_for`, {
+      content: {
+        profileIds: ['default'],
+        name: username
+      },
+      credentials: {
+        local: {
+          username: username,
+          password: 'test'
+        }
+      }
+    })
+
+    cy.visit('/#/security/users')
+    cy.get(`[data-cy="local-strategy-username-${username}"]`)
+      .should('be.visible')
+      .should('contain', username)
+  })
+
   it('Should be able to create an user without strategy', () => {
     cy.visit(`/#/security/users/create`)
 
-    cy.get('[data-cy=UserBasic-kuid]').type("without-credentials")
+    cy.get('[data-cy=UserBasic-kuid]').type('without-credentials')
     cy.get('[data-cy="UserProfileList-select"]').select('admin')
     cy.get('[data-cy=CredentialsSelector-local-username]').clear()
     cy.get('[data-cy=CredentialsSelector-local-password]').clear()
     cy.get('[data-cy="UserUpdate-submit"]').click({ force: true })
     cy.get('[id="collapse-without-credentials"]')
-    .contains("credentials:")
-    .next()
-    .should('not.contain', 'local:')
-    .should("have.class", "json-formatter-empty")
+      .contains('credentials:')
+      .next()
+      .should('not.contain', 'local:')
+      .should('have.class', 'json-formatter-empty')
   })
 })


### PR DESCRIPTION
## What does this PR do ?
As the title suggests, on the **Security:Users** page, display the user local strategy `username` as the list item title **if one is found**.

### How should this be manually tested?
Clone, Serve and [head to the users page](http://localhost:8080/#/security/users) to see that user items can now be easily identified.

![image](https://user-images.githubusercontent.com/2495908/122250718-2e463200-ceca-11eb-93d3-e6cd56421b7e.png)

Closes #832 