### PR TITLE
Fix/Increase the search profile count to improve user creation drop-down

### DIFF
--- a/src/services/kuzzleWrapper-v1.ts
+++ b/src/services/kuzzleWrapper-v1.ts
@@ -205,7 +205,7 @@ export class KuzzleWrapperV1 {
   async performSearchProfiles(filters = {}, pagination = {}) {
     const result = await this.kuzzle.security.searchProfiles(
       { ...filters },
-      { size: 100, ...pagination }
+      { size: 1000, ...pagination }
     )
 
     const profiles = result.hits.map(document => {


### PR DESCRIPTION
## What does this PR do ?

As the title suggests, increased the number of requested profiles, so the user creation drop-down correctly show at least 1k profiles.

Closes #892 