### PR TITLE
Add import/export API actions

### DIFF
--- a/src/components/ApiAction.vue
+++ b/src/components/ApiAction.vue
@@ -38,87 +38,80 @@
       <b-container fluid class="h-100">
         <b-row class="h-100">
           <b-col cols="12" v-if="loading"> </b-col>
-          <b-col cols="12" v-else>
-            <b-row class="h-100">
-              <b-col cols="12">
-                <b-card no-body class="px-0 h-100">
-                  <b-tabs card content-class="px-0 mt-3 tabsHeight">
-                    <b-tab
-                      v-for="(tabContent, tabIdx) of tabs"
-                      :key="`query-${tabIdx}-${tabContent.name}`"
-                      :active="currentTabIdx === tabIdx"
-                      @click.prevent=""
-                      class="px-2 py-0"
-                      title-link-class="px-3 py-0 titleItem"
+          <b-col cols="12" class="h-100" v-else>
+            <b-card no-body class="px-0 h-100">
+              <b-tabs card content-class="px-0 mt-3 tabsHeight">
+                <b-tab
+                  v-for="(tabContent, tabIdx) of tabs"
+                  :key="`query-${tabIdx}-${tabContent.name}`"
+                  :active="currentTabIdx === tabIdx"
+                  @click.prevent=""
+                  class="px-2 py-0"
+                  title-link-class="px-3 py-0 titleItem"
+                >
+                  <template #title>
+                    <b-row
+                      align-v="center"
+                      class="tabTitle"
+                      v-b-tooltip.hover
+                      :data-cy="`api-actions-tab-${tabIdx}`"
+                      :title="tabContent.name"
                     >
-                      <template #title>
-                        <b-row
-                          align-v="center"
-                          class="tabTitle"
-                          v-b-tooltip.hover
-                          :data-cy="`api-actions-tab-${tabIdx}`"
-                          :title="tabContent.name"
-                        >
-                          <b-col
-                            cols="9"
-                            class="text-left py-3 pointer"
-                            @click="setCurrentTab(tabIdx)"
-                          >
-                            <span>
-                              {{ formatTabName(tabContent) }}
-                            </span>
-                          </b-col>
-                          <b-col cols="3" class="py-3">
-                            <i
-                              class="fas fa-times pointer"
-                              @click="closeTab(tabIdx)"
-                            />
-                          </b-col>
-                        </b-row>
-                      </template>
-                      <QueryCard
-                        class="px-0"
-                        :query="tabContent.query"
-                        :tabIdx="tabIdx"
-                        :api="api"
-                        :openapi="openapi"
-                        :response="tabContent.response"
-                        @saveQuery="saveQuery"
-                        @queryChanged="onQueryChanged"
-                        @performQuery="performQuery"
-                      />
-                    </b-tab>
-                    <template #tabs-end>
-                      <b-row
-                        align-v="center"
-                        class="px-3"
-                        @click.prevent="addNewTab"
+                      <b-col
+                        cols="9"
+                        class="text-left py-3 pointer"
+                        @click="setCurrentTab(tabIdx)"
                       >
-                        <b-col cols="12" class="text-center my-3 pointer">
-                          <b data-cy="api-actions-tab-plus">+</b>
-                        </b-col>
-                      </b-row>
-                    </template>
-                    <template #empty>
-                      <b-row align-v="center" align-h="center" class="h-100">
-                        <b-col cols="4">
-                          <b-card title="No API action opened.">
-                            <b-card-text>
-                              <p>
-                                You can open a saved action in the left menu or
-                                <b-button variant="primary" @click="addNewTab"
-                                  >create one</b-button
-                                >
-                              </p>
-                            </b-card-text>
-                          </b-card>
-                        </b-col>
-                      </b-row>
-                    </template>
-                  </b-tabs>
-                </b-card>
-              </b-col>
-            </b-row>
+                        <span>
+                          {{ formatTabName(tabContent) }}
+                        </span>
+                      </b-col>
+                      <b-col cols="3" class="py-3">
+                        <i
+                          class="fas fa-times pointer"
+                          @click="closeTab(tabIdx)"
+                        />
+                      </b-col>
+                    </b-row>
+                  </template>
+                  <QueryCard
+                    class="px-0"
+                    :query="tabContent.query"
+                    :tabIdx="tabIdx"
+                    :api="api"
+                    :openapi="openapi"
+                    :response="tabContent.response"
+                    @saveQuery="saveQuery"
+                    @queryChanged="onQueryChanged"
+                    @performQuery="performQuery"
+                  />
+                </b-tab>
+                <template #tabs-end>
+                  <b
+                    @click.prevent="addNewTab"
+                    class="px-3 my-3 text-center pointer"
+                    data-cy="api-actions-tab-plus"
+                    >+</b
+                  >
+                </template>
+                <template #empty>
+                  <b-row align-v="center" align-h="center" class="h-100">
+                    <b-col cols="4">
+                      <b-card title="No API action opened.">
+                        <b-card-text>
+                          <p>
+                            You can open a saved action in the left menu or
+                            <b-button variant="primary" @click="addNewTab"
+                              >create one</b-button
+                            >
+                          </p>
+                        </b-card-text>
+                      </b-card>
+                    </b-col>
+                  </b-row>
+                </template>
+              </b-tabs>
+            </b-card>
           </b-col>
         </b-row>
       </b-container>

--- a/src/components/ApiAction.vue
+++ b/src/components/ApiAction.vue
@@ -17,6 +17,9 @@
     <MultipaneResizer data-cy="sidebarResizer" />
     <div class="DataLayout-contentWrapper-vertical">
       <b-container fluid class="h-100">
+        <b-row>
+          <b-button v-b-modal.export-actions>Export API Actions</b-button>
+        </b-row>
         <b-row align-v="stretch" class="h-100">
           <b-col cols="12" v-if="loading"> </b-col>
           <b-col cols="12" v-else>
@@ -40,7 +43,7 @@
                     >
                       <b-col
                         cols="9"
-                        class=" text-left py-3 pointer"
+                        class="text-left py-3 pointer"
                         @click="setCurrentTab(tabIdx)"
                       >
                         <span>
@@ -78,6 +81,22 @@
                     </b-col>
                   </b-row>
                 </template>
+                <template #empty>
+                  <b-row align-v="center" align-h="center" class="h-100">
+                    <b-col cols="4">
+                      <b-card title="No API action opened.">
+                        <b-card-text>
+                          <p>
+                            You can open a saved action in the left menu or
+                            <b-button variant="primary" @click="addNewTab"
+                              >create one</b-button
+                            >
+                          </p>
+                        </b-card-text>
+                      </b-card>
+                    </b-col>
+                  </b-row>
+                </template>
               </b-tabs>
             </b-card>
           </b-col>
@@ -88,6 +107,7 @@
       :isQueryNameValid="isQueryNameValid"
       @storeNewQuery="storeNewQuery"
     />
+    <ExportActionsModal />
   </Multipane>
 </template>
 
@@ -95,6 +115,7 @@
 import SaveQueryModal from '@/components/ApiAction/SaveQueryModal'
 import QueryList from '@/components/ApiAction/QueryList'
 import QueryCard from '@/components/ApiAction/QueryCard'
+import ExportActionsModal from '@/components/ApiAction/ExportActionsModal'
 
 import { Multipane, MultipaneResizer } from 'vue-multipane'
 import { mapGetters } from 'vuex'
@@ -107,7 +128,8 @@ export default {
     MultipaneResizer,
     QueryCard,
     SaveQueryModal,
-    QueryList
+    QueryList,
+    ExportActionsModal
   },
   data() {
     return {

--- a/src/components/ApiAction.vue
+++ b/src/components/ApiAction.vue
@@ -12,93 +12,111 @@
         :currentQueryName="currentQueryName"
         @deleteSavedQuery="deleteSavedQuery"
         @loadSavedQuery="loadSavedQuery"
-      />
+      >
+        <template #actions>
+          <b-button
+            class="mb-2 mt-2"
+            block
+            variant="outline-primary"
+            v-b-modal.export-actions
+            >Export API Actions</b-button
+          >
+          <b-button
+            class="mb-4"
+            block
+            variant="outline-primary"
+            v-b-modal.import-actions
+            >Import API Actions</b-button
+          >
+        </template>
+      </QueryList>
     </div>
     <MultipaneResizer data-cy="sidebarResizer" />
     <div class="DataLayout-contentWrapper-vertical">
       <b-container fluid class="h-100">
-        <b-row>
-          <b-button v-b-modal.export-actions>Export API Actions</b-button>
-        </b-row>
-        <b-row align-v="stretch" class="h-100">
+        <b-row class="h-100">
           <b-col cols="12" v-if="loading"> </b-col>
           <b-col cols="12" v-else>
-            <b-card no-body class="px-0 h-100">
-              <b-tabs card content-class="px-0 mt-3 tabsHeight">
-                <b-tab
-                  v-for="(tabContent, tabIdx) of tabs"
-                  :key="`query-${tabIdx}-${tabContent.name}`"
-                  :active="currentTabIdx === tabIdx"
-                  @click.prevent=""
-                  class="px-2 py-0"
-                  title-link-class="px-3 py-0 titleItem"
-                >
-                  <template #title>
-                    <b-row
-                      align-v="center"
-                      class="tabTitle"
-                      v-b-tooltip.hover
-                      :data-cy="`api-actions-tab-${tabIdx}`"
-                      :title="tabContent.name"
+            <b-row class="h-100">
+              <b-col cols="12">
+                <b-card no-body class="px-0 h-100">
+                  <b-tabs card content-class="px-0 mt-3 tabsHeight">
+                    <b-tab
+                      v-for="(tabContent, tabIdx) of tabs"
+                      :key="`query-${tabIdx}-${tabContent.name}`"
+                      :active="currentTabIdx === tabIdx"
+                      @click.prevent=""
+                      class="px-2 py-0"
+                      title-link-class="px-3 py-0 titleItem"
                     >
-                      <b-col
-                        cols="9"
-                        class="text-left py-3 pointer"
-                        @click="setCurrentTab(tabIdx)"
+                      <template #title>
+                        <b-row
+                          align-v="center"
+                          class="tabTitle"
+                          v-b-tooltip.hover
+                          :data-cy="`api-actions-tab-${tabIdx}`"
+                          :title="tabContent.name"
+                        >
+                          <b-col
+                            cols="9"
+                            class="text-left py-3 pointer"
+                            @click="setCurrentTab(tabIdx)"
+                          >
+                            <span>
+                              {{ formatTabName(tabContent) }}
+                            </span>
+                          </b-col>
+                          <b-col cols="3" class="py-3">
+                            <i
+                              class="fas fa-times pointer"
+                              @click="closeTab(tabIdx)"
+                            />
+                          </b-col>
+                        </b-row>
+                      </template>
+                      <QueryCard
+                        class="px-0"
+                        :query="tabContent.query"
+                        :tabIdx="tabIdx"
+                        :api="api"
+                        :openapi="openapi"
+                        :response="tabContent.response"
+                        @saveQuery="saveQuery"
+                        @queryChanged="onQueryChanged"
+                        @performQuery="performQuery"
+                      />
+                    </b-tab>
+                    <template #tabs-end>
+                      <b-row
+                        align-v="center"
+                        class="px-3"
+                        @click.prevent="addNewTab"
                       >
-                        <span>
-                          {{ formatTabName(tabContent) }}
-                        </span>
-                      </b-col>
-                      <b-col cols="3" class="py-3">
-                        <i
-                          class="fas fa-times pointer"
-                          @click="closeTab(tabIdx)"
-                        />
-                      </b-col>
-                    </b-row>
-                  </template>
-                  <QueryCard
-                    class="px-0"
-                    :query="tabContent.query"
-                    :tabIdx="tabIdx"
-                    :api="api"
-                    :openapi="openapi"
-                    :response="tabContent.response"
-                    @saveQuery="saveQuery"
-                    @queryChanged="onQueryChanged"
-                    @performQuery="performQuery"
-                  />
-                </b-tab>
-                <template #tabs-end>
-                  <b-row
-                    align-v="center"
-                    class="px-3"
-                    @click.prevent="addNewTab"
-                  >
-                    <b-col cols="12" class="text-center my-3 pointer">
-                      <b data-cy="api-actions-tab-plus">+</b>
-                    </b-col>
-                  </b-row>
-                </template>
-                <template #empty>
-                  <b-row align-v="center" align-h="center" class="h-100">
-                    <b-col cols="4">
-                      <b-card title="No API action opened.">
-                        <b-card-text>
-                          <p>
-                            You can open a saved action in the left menu or
-                            <b-button variant="primary" @click="addNewTab"
-                              >create one</b-button
-                            >
-                          </p>
-                        </b-card-text>
-                      </b-card>
-                    </b-col>
-                  </b-row>
-                </template>
-              </b-tabs>
-            </b-card>
+                        <b-col cols="12" class="text-center my-3 pointer">
+                          <b data-cy="api-actions-tab-plus">+</b>
+                        </b-col>
+                      </b-row>
+                    </template>
+                    <template #empty>
+                      <b-row align-v="center" align-h="center" class="h-100">
+                        <b-col cols="4">
+                          <b-card title="No API action opened.">
+                            <b-card-text>
+                              <p>
+                                You can open a saved action in the left menu or
+                                <b-button variant="primary" @click="addNewTab"
+                                  >create one</b-button
+                                >
+                              </p>
+                            </b-card-text>
+                          </b-card>
+                        </b-col>
+                      </b-row>
+                    </template>
+                  </b-tabs>
+                </b-card>
+              </b-col>
+            </b-row>
           </b-col>
         </b-row>
       </b-container>
@@ -107,7 +125,11 @@
       :isQueryNameValid="isQueryNameValid"
       @storeNewQuery="storeNewQuery"
     />
-    <ExportActionsModal />
+    <ExportActionsModal :tabs="tabs" />
+    <ImportActionsModal
+      :savedActionNames="savedActionNames"
+      @import-actions="importActions"
+    />
   </Multipane>
 </template>
 
@@ -116,6 +138,7 @@ import SaveQueryModal from '@/components/ApiAction/SaveQueryModal'
 import QueryList from '@/components/ApiAction/QueryList'
 import QueryCard from '@/components/ApiAction/QueryCard'
 import ExportActionsModal from '@/components/ApiAction/ExportActionsModal'
+import ImportActionsModal from '@/components/ApiAction/ImportActionsModal'
 
 import { Multipane, MultipaneResizer } from 'vue-multipane'
 import { mapGetters } from 'vuex'
@@ -129,7 +152,8 @@ export default {
     QueryCard,
     SaveQueryModal,
     QueryList,
-    ExportActionsModal
+    ExportActionsModal,
+    ImportActionsModal
   },
   data() {
     return {
@@ -146,6 +170,9 @@ export default {
   computed: {
     ...mapGetters('kuzzle', ['$kuzzle', 'currentEnvironment']),
     ...mapGetters('auth', ['canGetPublicApi', 'canGetOpenApi']),
+    savedActionNames() {
+      return this.savedQueries.map(q => q.name)
+    },
     emptyTab() {
       return {
         query: {
@@ -173,6 +200,16 @@ export default {
     }
   },
   methods: {
+    importActions(actions) {
+      for (const action of actions) {
+        action.idx = this.savedQueries.length
+        action.savedIdx = this.savedQueries.length
+        action.response = ''
+        action.saved = true
+        this.savedQueries.push(JSON.parse(JSON.stringify(action)))
+      }
+      this.storeQueriesToLocalStorage()
+    },
     closeAlert() {
       this.showAlert = false
     },

--- a/src/components/ApiAction.vue
+++ b/src/components/ApiAction.vue
@@ -19,6 +19,7 @@
             block
             variant="outline-primary"
             v-b-modal.export-actions
+            data-cy="button-export-api-actions"
             >Export API Actions</b-button
           >
           <b-button
@@ -26,6 +27,7 @@
             block
             variant="outline-primary"
             v-b-modal.import-actions
+            data-cy="button-import-api-actions"
             >Import API Actions</b-button
           >
         </template>

--- a/src/components/ApiAction/ExportActionsModal.vue
+++ b/src/components/ApiAction/ExportActionsModal.vue
@@ -10,8 +10,9 @@
       <b-button
         :disabled="!Boolean(apiActions.length)"
         variant="primary"
-        download="connections.json"
+        download="APIActions.json"
         :href="exportURL"
+        data-cy="modal-button-export-action"
         >Export
       </b-button>
     </template>
@@ -19,7 +20,10 @@
     <b-form-checkbox-group v-model="selectedActionIds">
       <b-table small :fields="tableFields" :items="apiActions" responsive="sm">
         <template #cell(checkbox)="data">
-          <b-form-checkbox :value="data.item.id" />
+          <b-form-checkbox
+            :data-cy="`modal-export-action-checkbox-${data.item.id}`"
+            :value="data.item.id"
+          />
         </template>
         <template #cell(name)="data">
           {{ data.item.name.substring(0, 20)

--- a/src/components/ApiAction/ExportActionsModal.vue
+++ b/src/components/ApiAction/ExportActionsModal.vue
@@ -4,10 +4,17 @@
     id="export-actions"
     title="Export API Actions"
     size="lg"
-    @ok="handleOk"
     @shown="fetchQueries"
-    okTitle="Export"
   >
+    <template #modal-ok>
+      <b-button
+        :disabled="!Boolean(apiActions.length)"
+        variant="primary"
+        download="connections.json"
+        :href="exportURL"
+        >Export
+      </b-button>
+    </template>
     <p class="my-4">Select the actions you want to export</p>
     <b-form-checkbox-group v-model="selectedActionIds">
       <b-table small :fields="tableFields" :items="apiActions" responsive="sm">
@@ -38,6 +45,23 @@ export default {
     }
   },
   computed: {
+    exportURL() {
+      const selectedActions = this.apiActions.filter(action =>
+        this.selectedActionIds.includes(action.id)
+      )
+      selectedActions.map(action => {
+        delete action.id
+        delete action.idx
+        delete action.env
+      })
+      const data = JSON.stringify(selectedActions)
+
+      const blob = new Blob([JSON.stringify(data)], {
+        type: 'application/json'
+      })
+
+      return URL.createObjectURL(blob)
+    },
     tableFields() {
       return [
         { key: 'checkbox', label: 'Selected' },
@@ -54,41 +78,6 @@ export default {
   mounted() {},
   watch: {},
   methods: {
-    handleOk() {
-      const selectedActions = this.apiActions.filter(action =>
-        this.selectedActionIds.includes(action.id)
-      )
-      selectedActions.map(action => {
-        delete action.id
-        delete action.idx
-        delete action.env
-      })
-      const data = JSON.stringify(selectedActions)
-      const blob = new Blob([data], { type: 'text/plain' })
-      const e = document.createEvent('MouseEvents'),
-        a = document.createElement('a')
-      a.download = 'APIActions.json'
-      a.href = window.URL.createObjectURL(blob)
-      a.dataset.downloadurl = ['text/json', a.download, a.href].join(':')
-      e.initEvent(
-        'click',
-        true,
-        false,
-        window,
-        0,
-        0,
-        0,
-        0,
-        0,
-        false,
-        false,
-        false,
-        false,
-        0,
-        null
-      )
-      a.dispatchEvent(e)
-    },
     fetchQueries() {
       this.apiActions = []
       let storedActions = localStorage.getItem('storedQueries')

--- a/src/components/ApiAction/ExportActionsModal.vue
+++ b/src/components/ApiAction/ExportActionsModal.vue
@@ -53,14 +53,14 @@ export default {
       const selectedActions = this.apiActions.filter(action =>
         this.selectedActionIds.includes(action.id)
       )
-      selectedActions.map(action => {
+      selectedActions.forEach(action => {
         delete action.id
         delete action.idx
         delete action.env
       })
-      const data = JSON.stringify(selectedActions)
+      const data = JSON.stringify(selectedActions, null, 2)
 
-      const blob = new Blob([JSON.stringify(data)], {
+      const blob = new Blob([data], {
         type: 'application/json'
       })
 

--- a/src/components/ApiAction/ExportActionsModal.vue
+++ b/src/components/ApiAction/ExportActionsModal.vue
@@ -1,11 +1,12 @@
 <template>
   <b-modal
+    scrollable
     id="export-actions"
     title="Export API Actions"
-    @shown="fetchQueries"
     size="lg"
     @ok="handleOk"
-    scrollable
+    @shown="fetchQueries"
+    okTitle="Export"
   >
     <p class="my-4">Select the actions you want to export</p>
     <b-form-checkbox-group v-model="selectedActionIds">
@@ -25,6 +26,11 @@
 <script>
 export default {
   name: 'ExportActionsModal',
+  props: {
+    tabs: {
+      default: []
+    }
+  },
   data() {
     return {
       apiActions: [],
@@ -40,13 +46,15 @@ export default {
         { key: 'query.controller', label: 'Controller' },
         { key: 'query.action', label: 'Action' }
       ]
+    },
+    currentEnvironmentId() {
+      return this.$store.state.kuzzle.currentId
     }
   },
   mounted() {},
   watch: {},
   methods: {
     handleOk() {
-      this.$log.debug(this.selectedActionIds, this.apiActions)
       const selectedActions = this.apiActions.filter(action =>
         this.selectedActionIds.includes(action.id)
       )
@@ -55,7 +63,6 @@ export default {
         delete action.idx
         delete action.env
       })
-      this.$log.debug(selectedActions)
       const data = JSON.stringify(selectedActions)
       const blob = new Blob([data], { type: 'text/plain' })
       const e = document.createEvent('MouseEvents'),
@@ -104,6 +111,9 @@ export default {
           this.apiActions.push(action)
         })
       })
+      this.selectedActionIds = this.tabs
+        .filter(tab => tab.saved)
+        .map(tab => `${this.currentEnvironmentId}-${tab.name}`)
     }
   }
 }

--- a/src/components/ApiAction/ExportActionsModal.vue
+++ b/src/components/ApiAction/ExportActionsModal.vue
@@ -1,0 +1,112 @@
+<template>
+  <b-modal
+    id="export-actions"
+    title="Export API Actions"
+    @shown="fetchQueries"
+    size="lg"
+    @ok="handleOk"
+    scrollable
+  >
+    <p class="my-4">Select the actions you want to export</p>
+    <b-form-checkbox-group v-model="selectedActionIds">
+      <b-table small :fields="tableFields" :items="apiActions" responsive="sm">
+        <template #cell(checkbox)="data">
+          <b-form-checkbox :value="data.item.id" />
+        </template>
+        <template #cell(name)="data">
+          {{ data.item.name.substring(0, 20)
+          }}{{ data.item.name.length > 20 ? '...' : '' }}
+        </template>
+      </b-table>
+    </b-form-checkbox-group>
+  </b-modal>
+</template>
+
+<script>
+export default {
+  name: 'ExportActionsModal',
+  data() {
+    return {
+      apiActions: [],
+      selectedActionIds: []
+    }
+  },
+  computed: {
+    tableFields() {
+      return [
+        { key: 'checkbox', label: 'Selected' },
+        { key: 'env', label: 'Environment' },
+        { key: 'name', label: 'Name' },
+        { key: 'query.controller', label: 'Controller' },
+        { key: 'query.action', label: 'Action' }
+      ]
+    }
+  },
+  mounted() {},
+  watch: {},
+  methods: {
+    handleOk() {
+      this.$log.debug(this.selectedActionIds, this.apiActions)
+      const selectedActions = this.apiActions.filter(action =>
+        this.selectedActionIds.includes(action.id)
+      )
+      selectedActions.map(action => {
+        delete action.id
+        delete action.idx
+        delete action.env
+      })
+      this.$log.debug(selectedActions)
+      const data = JSON.stringify(selectedActions)
+      const blob = new Blob([data], { type: 'text/plain' })
+      const e = document.createEvent('MouseEvents'),
+        a = document.createElement('a')
+      a.download = 'APIActions.json'
+      a.href = window.URL.createObjectURL(blob)
+      a.dataset.downloadurl = ['text/json', a.download, a.href].join(':')
+      e.initEvent(
+        'click',
+        true,
+        false,
+        window,
+        0,
+        0,
+        0,
+        0,
+        0,
+        false,
+        false,
+        false,
+        false,
+        0,
+        null
+      )
+      a.dispatchEvent(e)
+    },
+    fetchQueries() {
+      this.apiActions = []
+      let storedActions = localStorage.getItem('storedQueries')
+      if (!storedActions) {
+        this.$bvToast.toast('No saved API Action to export...', {
+          title: 'Error',
+          variant: 'warning',
+          toaster: 'b-toaster-bottom-right',
+          appendToast: true,
+          dismissible: true,
+          noAutoHide: true
+        })
+        this.$bvModal.hide('export-actions')
+      }
+      storedActions = JSON.parse(storedActions)
+      Object.keys(storedActions).forEach(env => {
+        storedActions[env].forEach(action => {
+          action.env = env
+          action.id = `${env}-${action.name}`
+          this.apiActions.push(action)
+        })
+      })
+    }
+  }
+}
+</script>
+
+<style scoped></style>

--- a/src/components/ApiAction/ImportActionsModal.vue
+++ b/src/components/ApiAction/ImportActionsModal.vue
@@ -175,7 +175,7 @@ export default {
       for (const file of this.files) {
         promises.push(await this.readFile(file))
       }
-      Promise.all(promises)
+      await Promise.all(promises)
       .then(values => {
         for (const value of values) {
           fileContent[value.file.name] = value.content

--- a/src/components/ApiAction/ImportActionsModal.vue
+++ b/src/components/ApiAction/ImportActionsModal.vue
@@ -5,6 +5,7 @@
     title="Import API Actions"
     size="lg"
     okTitle="Import"
+    @hide="resetForm"
     :ok-disabled="validNames || !Boolean(files.length)"
     @ok="handleImport"
   >
@@ -100,11 +101,16 @@ export default {
     }
   },
   methods: {
+    resetForm() {
+      this.file = null
+      this.files = []
+      this.actions = []
+    },
     handleImport() {
       this.$emit('import-actions', this.actions)
     },
     async isInvalidFile(file) {
-      if (this.files.find(f => JSON.stringify(file) === JSON.stringify(f))) {
+      if (this.files.find(f => f.name === file.name  && f.size === file.size)) {
          this.$bvToast.toast(`File ${this.file.name} already added!`, {
           title: 'Warning',
           variant: 'warning',

--- a/src/components/ApiAction/ImportActionsModal.vue
+++ b/src/components/ApiAction/ImportActionsModal.vue
@@ -1,0 +1,176 @@
+<template>
+  <b-modal
+    scrollable
+    id="import-actions"
+    title="Import API Actions"
+    size="lg"
+    okTitle="Import"
+    :ok-disabled="validNames || !Boolean(files.length)"
+    @ok="handleImport"
+  >
+    <b-container>
+      <b-row>
+        <b-col cols="12" class="text-center mb-3">
+          Imported actions will be added to the current environment.
+        </b-col>
+        <b-col cols="12" class="text-center mb-3">
+          <b-form-file
+            v-model="file"
+            autofocus
+            size="lg"
+            accept=".json"
+            placeholder="Choose a file or drop it here..."
+            drop-placeholder="Drop file here..."
+          ></b-form-file>
+        </b-col>
+        <b-col cols="12" v-if="files.length" class="mb-3">
+          <b-card no-body header="Files">
+            <b-list-group>
+              <b-list-group-item
+                v-for="file in files"
+                :key="`${file.name}-${file.lastModified}`"
+                class="d-flex justify-content-between align-items-center"
+                :variant="file.isInvalid ? 'danger' : ''"
+              >
+                {{ file.name }} {{ file.size }} {{ file.size ? 'kb' : 'N/A' }}
+                <i @click="removeFile(file)" class="fas fa-trash" />
+              </b-list-group-item>
+            </b-list-group>
+          </b-card>
+        </b-col>
+        <b-col cols="12" v-if="actions.length">
+          <b-card no-body header="API Actions">
+            <b-table :fields="tableFields" :items="actions" class="mb-0">
+              <template #cell(name)="data">
+                <b-form-input
+                  :id="`name-input-${data.index}`"
+                  size="sm"
+                  :state="!savedActionNames.includes(data.item.name)"
+                  v-model="data.item.name"
+                >
+                </b-form-input>
+                <b-form-invalid-feedback
+                  :id="`name-input-${data.index}-feedback`"
+                >
+                  You already have a saved action with that name.
+                </b-form-invalid-feedback>
+              </template>
+            </b-table>
+          </b-card>
+        </b-col>
+      </b-row>
+    </b-container>
+  </b-modal>
+</template>
+
+<script>
+/* eslint-disable */
+export default {
+  name: 'import-actions-modal',
+  props: {
+    savedActionNames: {
+      required: true
+    }
+  },
+  data() {
+    return {
+      file: null,
+      files: [],
+      actions: [],
+      tableFields: [
+        { key: 'name', label: 'Name' },
+        { key: 'query.controller', label: 'Controller' },
+        { key: 'query.action', label: 'Action' }
+      ]
+    }
+  },
+  computed: {
+    validNames() {
+      return this.actions.some(action => this.savedActionNames.includes(action.name))
+    }
+  },
+  watch: {
+    file(value) {
+      if (value) {
+        this.fileAdded(value)
+      }
+    },
+    files(value) {
+      this.filesChange(value)
+    }
+  },
+  methods: {
+    handleImport() {
+      this.$emit('import-actions', this.actions)
+    },
+    async isInvalidFile(file) {
+      if (this.files.find(f => JSON.stringify(file) === JSON.stringify(f))) {
+         this.$bvToast.toast(`File ${this.file.name} already added!`, {
+          title: 'Warning',
+          variant: 'warning',
+          toaster: 'b-toaster-bottom-right',
+          appendToast: true,
+          dismissible: true,
+          noAutoHide: true
+        })
+        return true
+      }
+      try {
+        await this.readFile(file)
+        return false
+      } catch (error) {
+         this.$bvToast.toast(`Unable to parse file: ${this.file.name}`, {
+          title: 'Error',
+          variant: 'danger',
+          toaster: 'b-toaster-bottom-right',
+          appendToast: true,
+          dismissible: true,
+          noAutoHide: true
+        })
+        return true
+      }
+    },
+    async readFile(file) {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader()
+        reader.readAsText(file, 'UTF-8')
+        reader.onload = evt => {
+          try {
+            resolve(JSON.parse(evt.target.result))
+          } catch (error) {
+            reject(error)
+          }
+        }
+        reader.onerror = evt => {
+          reject()
+        }
+      })
+    },
+    async fileAdded() {
+      const isInvalidFile = await this.isInvalidFile(this.file)
+      if (!isInvalidFile) {
+        this.files.push(this.file)
+      }
+      this.file = null
+    },
+    async filesChange() {
+      const fileContent = {}
+      for (const file of this.files) {
+        fileContent[file.name] = await this.readFile(file)
+      }
+      this.actions = []
+      for (const [env, content] of Object.entries(fileContent)) {
+        this.actions = this.actions.concat(content)
+      }
+    },
+    removeFile(file) {
+      const files = this.files.filter(f => {
+        return f != file
+      })
+      this.$set(this, 'files', files)
+    }
+  }
+}
+</script>
+
+<style></style>

--- a/src/components/ApiAction/ImportActionsModal.vue
+++ b/src/components/ApiAction/ImportActionsModal.vue
@@ -4,11 +4,17 @@
     id="import-actions"
     title="Import API Actions"
     size="lg"
-    okTitle="Import"
     @hide="resetForm"
-    :ok-disabled="validNames || !Boolean(files.length)"
-    @ok="handleImport"
   >
+    <template #modal-ok>
+      <b-button
+        @click="handleImport"
+        :disabled="validNames || !Boolean(files.length)"
+        variant="primary"
+        data-cy="modal-button-import-action"
+        >Import
+      </b-button>
+    </template>
     <b-container>
       <b-row>
         <b-col cols="12" class="text-center mb-3">
@@ -22,6 +28,7 @@
             accept=".json"
             placeholder="Choose a file or drop it here..."
             drop-placeholder="Drop file here..."
+            data-cy="import-api-actions-file-input"
           ></b-form-file>
         </b-col>
         <b-col cols="12" v-if="files.length" class="mb-3">
@@ -46,6 +53,7 @@
                 <b-form-input
                   :id="`name-input-${data.index}`"
                   size="sm"
+                  :data-cy="`imported-action-name-editor-${data.index}`"
                   :state="!savedActionNames.includes(data.item.name)"
                   v-model="data.item.name"
                 >
@@ -87,7 +95,9 @@ export default {
   },
   computed: {
     validNames() {
-      return this.actions.some(action => this.savedActionNames.includes(action.name))
+      return this.actions.some(action =>
+        this.savedActionNames.includes(action.name)
+      )
     }
   },
   watch: {
@@ -110,8 +120,8 @@ export default {
       this.$emit('import-actions', this.actions)
     },
     async isInvalidFile(file) {
-      if (this.files.find(f => f.name === file.name  && f.size === file.size)) {
-         this.$bvToast.toast(`File ${this.file.name} already added!`, {
+      if (this.files.find(f => f.name === file.name && f.size === file.size)) {
+        this.$bvToast.toast(`File ${this.file.name} already added!`, {
           title: 'Warning',
           variant: 'warning',
           toaster: 'b-toaster-bottom-right',
@@ -125,7 +135,7 @@ export default {
         await this.readFile(file)
         return false
       } catch (error) {
-         this.$bvToast.toast(`Unable to parse file: ${this.file.name}`, {
+        this.$bvToast.toast(`Unable to parse file: ${this.file.name}`, {
           title: 'Error',
           variant: 'danger',
           toaster: 'b-toaster-bottom-right',

--- a/src/components/ApiAction/QueryList.vue
+++ b/src/components/ApiAction/QueryList.vue
@@ -18,33 +18,36 @@
               </b-col>
             </b-row>
             <template v-else>
-              <b-list-group class="leftNav-container" ref="leftNav-container">
-                <b-list-group-item
-                  v-for="query of paginatedQueries"
-                  class="px-3 py-0"
-                  :key="`saved-query-${query.idx}`"
-                  :active="query.idx === currentQueryIndex"
-                  :ref="`saved-query-${query.idx}`"
-                  :data-cy="`api-actions-saved-query-${query.name}`"
-                >
-                  <b-row align-v="center">
-                    <b-col
-                      cols="9"
-                      class="text-left py-3 pointer leftTab"
-                      @click="loadSavedQuery(query.idx)"
-                      :id="`query-list-${query.idx}`"
-                    >
-                      <span>{{ query.name }}</span>
-                    </b-col>
-                    <b-col cols="3" class="py-3">
-                      <i
-                        class="fas fa-trash pointer"
-                        @click="deleteSavedQuery(query)"
-                      />
-                    </b-col>
-                  </b-row>
-                </b-list-group-item>
-              </b-list-group>
+              <slot name="actions" />
+              <b-card no-body header="Saved API Actions">
+                <b-list-group class="leftNav-container" ref="leftNav-container">
+                  <b-list-group-item
+                    v-for="query of paginatedQueries"
+                    class="px-3 py-0"
+                    :key="`saved-query-${query.idx}`"
+                    :active="query.idx === currentQueryIndex"
+                    :ref="`saved-query-${query.idx}`"
+                    :data-cy="`api-actions-saved-query-${query.name}`"
+                  >
+                    <b-row align-v="center">
+                      <b-col
+                        cols="9"
+                        class="text-left py-3 pointer leftTab"
+                        @click="loadSavedQuery(query.idx)"
+                        :id="`query-list-${query.idx}`"
+                      >
+                        <span>{{ query.name }}</span>
+                      </b-col>
+                      <b-col cols="3" class="py-3">
+                        <i
+                          class="fas fa-trash pointer"
+                          @click="deleteSavedQuery(query)"
+                        />
+                      </b-col>
+                    </b-row>
+                  </b-list-group-item>
+                </b-list-group>
+              </b-card>
             </template>
           </b-card-text>
         </b-card-body>

--- a/src/components/ApiAction/QueryList.vue
+++ b/src/components/ApiAction/QueryList.vue
@@ -4,11 +4,8 @@
       <b-card class="h-100 backgroundCard" no-body>
         <b-card-body class="d-flex flex-column text-center m-0 p-0 h-100">
           <b-card-text class="px-1 py-3 h-100">
-            <b-row
-              align-v="center"
-              class="h-100"
-              v-if="!paginatedQueries.length"
-            >
+            <slot name="actions" />
+            <b-row class="h-100" v-if="!paginatedQueries.length">
               <b-col>
                 <b-card title="No API actions saved.">
                   <b-card-text>
@@ -18,7 +15,6 @@
               </b-col>
             </b-row>
             <template v-else>
-              <slot name="actions" />
               <b-card no-body header="Saved API Actions">
                 <b-list-group class="leftNav-container" ref="leftNav-container">
                   <b-list-group-item

--- a/src/components/ApiAction/SaveQueryModal.vue
+++ b/src/components/ApiAction/SaveQueryModal.vue
@@ -3,9 +3,10 @@
     id="modal-save-query"
     title="Choose a name for this query"
     @ok="handleOk"
+    @keydown.native.enter="handleOk"
     ok-title-html='<span data-cy="api-actions-modal-ok-button">OK</span>'
   >
-    <form ref="form" @submit.stop.prevent="handleSubmit">
+    <form ref="form" @submit.stop.prevent="handleOk">
       <b-form-group
         label="Name"
         label-for="name-input"

--- a/test/e2e/cypress/fixtures/APIActions.json
+++ b/test/e2e/cypress/fixtures/APIActions.json
@@ -1,0 +1,6 @@
+[
+  {
+    "query": { "controller": "index", "action": "create", "index": "indexName" },
+    "name": "queryName"
+  }
+]

--- a/test/e2e/cypress/integration/single-backend/api-actions.spec.js
+++ b/test/e2e/cypress/integration/single-backend/api-actions.spec.js
@@ -9,82 +9,91 @@ describe('API Actions - query', function() {
   })
 
   it('Should be able to perform a query', () => {
-    const indexName = "testindex"
+    const indexName = 'testindex'
     cy.waitOverlay()
     cy.visit(`/#/api-action`)
-    cy.get('[data-cy="api-actions-query-JSONEditor-0"] textarea.ace_text-input')
-    .type(`{selectall}{backspace}{
+    cy.get(
+      '[data-cy="api-actions-query-JSONEditor-0"] textarea.ace_text-input'
+    ).type(
+      `{selectall}{backspace}{
 "controller": "index",
 "action": "create",
-"index": "${indexName}"`, {
-      delay: 200,
-      force: true
-    })
+"index": "${indexName}"`,
+      {
+        delay: 200,
+        force: true
+      }
+    )
     cy.get('[data-cy="api-actions-run-button-0"]').click()
 
     cy.wait(1000)
 
-    cy.request('GET', `${kuzzleUrl}/${indexName}/_exists`)
-    .should((response) => {
+    cy.request('GET', `${kuzzleUrl}/${indexName}/_exists`).should(response => {
       expect(response.body.result).to.equals(true)
     })
   })
 
   it('Should display the query status and response', () => {
-    const indexName = "testindex"
+    const indexName = 'testindex'
     cy.waitOverlay()
     cy.visit(`/#/api-action`)
     cy.wait(500)
-    cy.get('[data-cy="api-actions-query-JSONEditor-0"] textarea.ace_text-input')
-    .type(`{selectall}{backspace}{
+    cy.get(
+      '[data-cy="api-actions-query-JSONEditor-0"] textarea.ace_text-input'
+    ).type(
+      `{selectall}{backspace}{
 "controller": "index",
 "action": "create",
-"index": "${indexName}"`, {
-      delay: 200,
-      force: true
-    })
+"index": "${indexName}"`,
+      {
+        delay: 200,
+        force: true
+      }
+    )
     cy.get('[data-cy="api-actions-run-button-0"]').click()
 
     cy.wait(1000)
 
     cy.get('[data-cy="api-actions-response-status-0"]').should('contain', '200')
     cy.get('[data-cy="api-actions-response-JSONEditor-0"]')
-    .should('contain', '"error": null')
-    .should('contain', '"action": "create"')
-    .should('contain', '"controller": "index"')
-    .should('contain', `"index": "${indexName}"`)
-    .should('contain', '"status": 200')
+      .should('contain', '"error": null')
+      .should('contain', '"action": "create"')
+      .should('contain', '"controller": "index"')
+      .should('contain', `"index": "${indexName}"`)
+      .should('contain', '"status": 200')
   })
 
   it('Should be able to set query controller using input', () => {
     cy.waitOverlay()
     cy.visit(`/#/api-action`)
-    cy.get('[data-cy="api-actions-controller-input-0"]').type("index")
-    cy.get('[data-cy="api-actions-query-JSONEditor-0"]')
-    .should('contain', '"controller": "index"')
+    cy.get('[data-cy="api-actions-controller-input-0"]').type('index')
+    cy.get('[data-cy="api-actions-query-JSONEditor-0"]').should(
+      'contain',
+      '"controller": "index"'
+    )
   })
 
   it('Should be able to set query action using input', () => {
     cy.waitOverlay()
     cy.visit(`/#/api-action`)
-    cy.get('[data-cy="api-actions-action-input-0"]').type("create")
-    cy.get('[data-cy="api-actions-query-JSONEditor-0"]')
-    .should('contain', '"action": "create"')
+    cy.get('[data-cy="api-actions-action-input-0"]').type('create')
+    cy.get('[data-cy="api-actions-query-JSONEditor-0"]').should(
+      'contain',
+      '"action": "create"'
+    )
   })
 
   it('Should be able to get query controllers available as options', () => {
     cy.waitOverlay()
     cy.visit(`/#/api-action`)
-    cy.get('#controllersList option')
-    .should('have.length.of.at.least', 1)
+    cy.get('#controllersList option').should('have.length.of.at.least', 1)
   })
 
   it('Should be able to get query actions available as options', () => {
     cy.waitOverlay()
     cy.visit(`/#/api-action`)
-    cy.get('[data-cy="api-actions-controller-input-0"]').type("index")
-    cy.get('#actionsList option')
-    .should('have.length.of.at.least', 1)
+    cy.get('[data-cy="api-actions-controller-input-0"]').type('index')
+    cy.get('#actionsList option').should('have.length.of.at.least', 1)
   })
 
   it('Should not display options if user has no rights (publicApi/openapi)', () => {
@@ -127,69 +136,85 @@ describe('API Actions - tabs and save', function() {
   it('Should be able to open a new tab', () => {
     cy.waitOverlay()
     cy.visit(`/#/api-action`)
-    cy.get('ul[role="tablist"] li')
-    .should('have.length', 1)
+    cy.get('ul[role="tablist"] li').should('have.length', 1)
     cy.get('[data-cy="api-actions-tab-plus"]').click()
-    cy.get('ul[role="tablist"] li')
-    .should('have.length', 2)
+    cy.get('ul[role="tablist"] li').should('have.length', 2)
   })
 
   it('Should persist query by tabs', () => {
     cy.waitOverlay()
     cy.visit(`/#/api-action`)
-    cy.get('[data-cy="api-actions-query-JSONEditor-0"] textarea.ace_text-input')
-    .type(`{selectall}{backspace}tab0`, {
+    cy.get(
+      '[data-cy="api-actions-query-JSONEditor-0"] textarea.ace_text-input'
+    ).type(`{selectall}{backspace}tab0`, {
       delay: 200,
       force: true
     })
     cy.get('[data-cy="api-actions-tab-plus"]').click()
-    cy.get('[data-cy="api-actions-query-JSONEditor-1"]')
-    .should('not.contain', 'tab0')
+    cy.get('[data-cy="api-actions-query-JSONEditor-1"]').should(
+      'not.contain',
+      'tab0'
+    )
     cy.get('[data-cy="api-actions-tab-0"]').click()
-    cy.get('[data-cy="api-actions-query-JSONEditor-0"]')
-    .should('contain', 'tab0')
+    cy.get('[data-cy="api-actions-query-JSONEditor-0"]').should(
+      'contain',
+      'tab0'
+    )
   })
 
   it('Should be able to save a new query', () => {
-    const queryName = "createIndexToto"
-    const envName = "valid"
+    const queryName = 'createIndexToto'
+    const envName = 'valid'
     cy.clearLocalStorage('storedQueries')
     cy.waitOverlay()
     cy.visit(`/#/api-action`)
-    cy.get('[data-cy="api-actions-query-JSONEditor-0"] textarea.ace_text-input')
-    .type(`{selectall}{backspace}{
+    cy.get(
+      '[data-cy="api-actions-query-JSONEditor-0"] textarea.ace_text-input'
+    ).type(
+      `{selectall}{backspace}{
 "controller": "index",
 "action": "create",
-"index": "toto"`, {
-      delay: 200,
-      force: true
-    })
+"index": "toto"`,
+      {
+        delay: 200,
+        force: true
+      }
+    )
     cy.get('[data-cy="api-actions-save-button-0"]').click()
-    cy.get('[data-cy="api-actions-modal-name-input"]')
-    .type(`{selectall}{backspace}${queryName}`, {
-      delay: 200,
-      force: true
-    })
+    cy.get('[data-cy="api-actions-modal-name-input"]').type(
+      `{selectall}{backspace}${queryName}`,
+      {
+        delay: 200,
+        force: true
+      }
+    )
     cy.get('[data-cy="api-actions-modal-ok-button"]').click()
     cy.get(`[data-cy="api-actions-saved-query-${queryName}"]`)
-    cy.window().then(
-      window => {
-        const storedQueries = JSON.parse(window.localStorage.getItem('storedQueries'))
-        const queryIdx = storedQueries[envName].findIndex(e => e.name === queryName);
-        expect(queryIdx).to.equals(0)
-        expect(storedQueries[envName][queryIdx].query.controller).to.equals("index")
-        expect(storedQueries[envName][queryIdx].query.action).to.equals("create")
-        expect(storedQueries[envName][queryIdx].query.index).to.equals("toto")
-      }
-   );
+    cy.window().then(window => {
+      const storedQueries = JSON.parse(
+        window.localStorage.getItem('storedQueries')
+      )
+      const queryIdx = storedQueries[envName].findIndex(
+        e => e.name === queryName
+      )
+      expect(queryIdx).to.equals(0)
+      expect(storedQueries[envName][queryIdx].query.controller).to.equals(
+        'index'
+      )
+      expect(storedQueries[envName][queryIdx].query.action).to.equals('create')
+      expect(storedQueries[envName][queryIdx].query.index).to.equals('toto')
+    })
   })
 
   it('Should be able to open a saved query', () => {
     const envName = 'valid'
-    const queryName = "createIndexToto"
+    const queryName = 'createIndexToto'
     const storedQueries = {
       [envName]: [
-        {"query":{"controller":"index","action":"create","index": "toto"},"name": queryName}
+        {
+          query: { controller: 'index', action: 'create', index: 'toto' },
+          name: queryName
+        }
       ]
     }
     localStorage.setItem('storedQueries', JSON.stringify(storedQueries))
@@ -198,18 +223,21 @@ describe('API Actions - tabs and save', function() {
 
     cy.get(`[data-cy="api-actions-saved-query-${queryName}"]`).click()
     cy.get('[data-cy="api-actions-query-JSONEditor-1"]')
-    .should('contain', '"controller": "index"')
-    .should('contain', '"action": "create"')
-    .should('contain', '"index": "toto"')
+      .should('contain', '"controller": "index"')
+      .should('contain', '"action": "create"')
+      .should('contain', '"index": "toto"')
   })
 
   it('Should be able to run a saved query', () => {
     const envName = 'valid'
-    const queryName = "createIndexToto"
+    const queryName = 'createIndexToto'
     const indexName = 'toto'
     const storedQueries = {
       [envName]: [
-        {"query":{"controller":"index","action":"create","index": indexName},"name": queryName}
+        {
+          query: { controller: 'index', action: 'create', index: indexName },
+          name: queryName
+        }
       ]
     }
     localStorage.setItem('storedQueries', JSON.stringify(storedQueries))
@@ -221,20 +249,22 @@ describe('API Actions - tabs and save', function() {
 
     cy.wait(1000)
 
-    cy.request('GET', `${kuzzleUrl}/${indexName}/_exists`)
-    .should((response) => {
+    cy.request('GET', `${kuzzleUrl}/${indexName}/_exists`).should(response => {
       expect(response.body.result).to.equals(true)
     })
   })
 
   it('Should be able to edit a saved query', () => {
     const envName = 'valid'
-    const queryName = "createIndexToto"
+    const queryName = 'createIndexToto'
     const indexName = 'toto'
     const indexName2 = 'titi'
     const storedQueries = {
       [envName]: [
-        {"query":{"controller":"index","action":"create","index": indexName},"name": queryName}
+        {
+          query: { controller: 'index', action: 'create', index: indexName },
+          name: queryName
+        }
       ]
     }
     localStorage.setItem('storedQueries', JSON.stringify(storedQueries))
@@ -243,39 +273,51 @@ describe('API Actions - tabs and save', function() {
 
     cy.get(`[data-cy="api-actions-saved-query-${queryName}"]`).click()
 
-    cy.get('[data-cy="api-actions-query-JSONEditor-1"] textarea.ace_text-input')
-    .type(`{selectall}{backspace}{
+    cy.get(
+      '[data-cy="api-actions-query-JSONEditor-1"] textarea.ace_text-input'
+    ).type(
+      `{selectall}{backspace}{
 "controller": "index",
 "action": "create",
-"index": "${indexName2}"`, {
-      delay: 200,
-      force: true
-    })
+"index": "${indexName2}"`,
+      {
+        delay: 200,
+        force: true
+      }
+    )
     cy.get('[data-cy="api-actions-save-button-1"]').click()
 
-    cy.window().then(
-      window => {
-        const storedQueries = JSON.parse(window.localStorage.getItem('storedQueries'))
-        const queryIdx = storedQueries[envName].findIndex(e => e.name === queryName);
-        expect(storedQueries[envName][queryIdx].query.index).to.equals(indexName2)
-      }
-   );
+    cy.window().then(window => {
+      const storedQueries = JSON.parse(
+        window.localStorage.getItem('storedQueries')
+      )
+      const queryIdx = storedQueries[envName].findIndex(
+        e => e.name === queryName
+      )
+      expect(storedQueries[envName][queryIdx].query.index).to.equals(indexName2)
+    })
   })
 
   it('Should be able to persist saved queries by environment', () => {
     const envName = 'valid'
     const envName2 = 'valid2'
-    const queryName = "createIndexToto"
-    const queryName2 = "createIndexTiti"
+    const queryName = 'createIndexToto'
+    const queryName2 = 'createIndexTiti'
     const indexName = 'toto'
     const indexName2 = 'titi'
     const backendVersion = Cypress.env('BACKEND_VERSION') || 2
     const storedQueries = {
       [envName]: [
-        {"query":{"controller":"index","action":"create","index": indexName},"name": queryName}
+        {
+          query: { controller: 'index', action: 'create', index: indexName },
+          name: queryName
+        }
       ],
       [envName2]: [
-        {"query":{"controller":"index","action":"create","index": indexName2},"name": queryName2}
+        {
+          query: { controller: 'index', action: 'create', index: indexName2 },
+          name: queryName2
+        }
       ]
     }
     localStorage.setItem('storedQueries', JSON.stringify(storedQueries))
@@ -324,5 +366,116 @@ describe('API Actions - tabs and save', function() {
     cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
     cy.visit(`/#/api-action`)
     cy.get(`[data-cy="api-actions-saved-query-${queryName2}"]`)
+  })
+
+  it('Should be able to export queries', () => {
+    const envName = 'valid'
+    const queryName = 'createIndexToto'
+    const indexName = 'toto'
+    const storedQueries = {
+      [envName]: [
+        {
+          query: { controller: 'index', action: 'create', index: indexName },
+          name: queryName
+        }
+      ]
+    }
+
+    const exportedQueries = [
+      {
+        query: { controller: 'index', action: 'create', index: indexName },
+        name: queryName
+      }
+    ]
+    localStorage.setItem('storedQueries', JSON.stringify(storedQueries))
+    cy.waitOverlay()
+    cy.visit(`/#/api-action`)
+
+    cy.get('[data-cy="button-export-api-actions"]').click()
+
+    cy.get(
+      `[data-cy="modal-export-action-checkbox-${envName}-${storedQueries[envName][0].name}"]`
+    ).check({ force: true })
+
+    cy.wait(1000)
+
+    cy.get('[data-cy="modal-button-export-action"]').should(
+      'have.attr',
+      'download',
+      `APIActions.json`
+    )
+
+    cy.get('[data-cy="modal-button-export-action"]')
+      .then(
+        anchor =>
+          new Cypress.Promise(resolve => {
+            const xhr = new XMLHttpRequest()
+            xhr.open('GET', anchor.prop('href'), true)
+            xhr.responseType = 'blob'
+            xhr.onload = () => {
+              if (xhr.status === 200) {
+                const blob = xhr.response
+                const reader = new FileReader()
+                reader.onload = () => {
+                  resolve(JSON.parse(reader.result))
+                }
+                reader.readAsText(blob)
+              }
+            }
+            xhr.send()
+          })
+      )
+      .should('equal', JSON.stringify(exportedQueries))
+  })
+
+  it('Should be able to import queries', () => {
+    const envName = 'valid'
+    const storedQueries = {
+      [envName]: []
+    }
+
+    localStorage.setItem('storedQueries', JSON.stringify(storedQueries))
+    cy.waitOverlay()
+    cy.visit(`/#/api-action`)
+
+    cy.get('[data-cy="button-import-api-actions"]').click()
+    cy.wait(1000)
+
+    cy.get('[data-cy="import-api-actions-file-input"]').attachFile(
+      'APIActions.json'
+    )
+
+    cy.get('[data-cy="modal-button-import-action"]').click()
+
+    cy.get(`[data-cy="api-actions-saved-query-queryName"]`).should('exist')
+  })
+
+  it.only('Should be able to import queries and change query name', () => {
+    const envName = 'valid'
+    const storedQueries = {
+      [envName]: []
+    }
+
+    localStorage.setItem('storedQueries', JSON.stringify(storedQueries))
+    cy.waitOverlay()
+    cy.visit(`/#/api-action`)
+
+    cy.get('[data-cy="button-import-api-actions"]').click()
+    cy.wait(1000)
+
+    cy.get('[data-cy="import-api-actions-file-input"]').attachFile(
+      'APIActions.json'
+    )
+
+    cy.get('[data-cy="imported-action-name-editor-0"]').type(
+      `{selectall}{backspace}changedQueryName`
+    )
+
+    cy.get('[data-cy="modal-button-import-action"]').click()
+
+    cy.get(`[data-cy="api-actions-saved-query-queryName"]`).should('not.exist')
+    cy.get(`[data-cy="api-actions-saved-query-changedQueryName"]`).should(
+      'exist'
+    )
   })
 })


### PR DESCRIPTION
## What does this PR do ?
Add import/export features to API Actions view

Buttons import/export to left corner in sidebar
export:
  - open modal with table listing all the saved queries of all env (in the localStorage)
  - allow to check one or more queries
  - export button modal-ok

import: 
  - open modal with file input (file explorer/drag n drop)
  - multifile import supported
  - list of files to import (size and remove button)
  - list of queries to import 
  - allow to edit queries name before import (inputstate (red/green) = name already used)

Tests added:
  - Export a query in file and check file content
  - Import a query with file 
  - Change a query name while importing

### How should this be manually tested?
  - Step 1 : create and save some queries
  - Step 2 : click the export button and check the file
  - Step 3 : delete your previous saved queries
  - Step 4 : click the import button and upload the previous downloaded file

### Other changes
/

### Boyscout
/

![Screenshot from 2021-07-01 17-50-55](https://user-images.githubusercontent.com/44427849/124155211-89655080-da96-11eb-808b-1a96eeed7e74.png)

![Screenshot from 2021-07-01 17-59-37](https://user-images.githubusercontent.com/44427849/124155253-96823f80-da96-11eb-9da2-61f6cfa84950.png)

![Screenshot from 2021-07-01 17-59-17](https://user-images.githubusercontent.com/44427849/124155276-9d10b700-da96-11eb-8ed1-430a9e0d7318.png)

