### PR TITLE
 Allow to search on _id in AdvancedFilter

### DIFF
--- a/src/components/Common/Filters/BasicFilter.vue
+++ b/src/components/Common/Filters/BasicFilter.vue
@@ -263,10 +263,13 @@ export default {
   computed: {
     ...mapGetters('kuzzle', ['wrapper']),
     selectAttributesValues() {
-      return Object.keys(this.mappingAttributes).map(a => ({
-        text: a,
-        value: a
-      }))
+      return [
+        { text: '_id', value: '_id' },
+        ...Object.keys(this.mappingAttributes).map(a => ({
+          text: a,
+          value: a
+        }))
+      ]
     },
     sortAttributesValues() {
       return Object.keys(this.mappingAttributes)


### PR DESCRIPTION
Fix #947 

Allow to search on _id in AdvancedFilter
:warning: doesn't work for a partial match since _id field can only be search following `term`, `terms`, `match` and `query_string`