### PR TITLE
Allow to hide the No Admin Banner 

### DIFF
--- a/src/components/Common/Environments/CreateEnvironment.vue
+++ b/src/components/Common/Environments/CreateEnvironment.vue
@@ -167,7 +167,8 @@ export default {
         port: 7512,
         color: null,
         ssl: useHttps,
-        backendMajorVersion: null
+        backendMajorVersion: null,
+        hideAdminBanner: false
       },
       submitting: false
     }
@@ -259,15 +260,15 @@ export default {
     }
   },
   mounted() {
-    if (this.environmentId && this.environments[this.environmentId]) {
-      this.environment.name = this.environments[this.environmentId].name
-      this.environment.host = this.environments[this.environmentId].host
-      this.environment.port = this.environments[this.environmentId].port
-      this.environment.color = this.environments[this.environmentId].color
-      this.environment.ssl = this.environments[this.environmentId].ssl
-      this.environment.backendMajorVersion = this.environments[
-        this.environmentId
-      ].backendMajorVersion
+    const currentEnv = this.environments[this.environmentId]
+    if (this.environmentId && currentEnv) {
+      this.environment.name = currentEnv.name
+      this.environment.host = currentEnv.host
+      this.environment.port = currentEnv.port
+      this.environment.color = currentEnv.color
+      this.environment.ssl = currentEnv.ssl
+      this.environment.backendMajorVersion = currentEnv.backendMajorVersion
+      this.environment.hideAdminBanner = currentEnv.hideAdminBanner
       this.$nextTick(() => this.showValidationErrors())
     } else {
       this.environment.name = null
@@ -276,6 +277,7 @@ export default {
       this.environment.color = DEFAULT_COLOR
       this.environment.ssl = useHttps
       this.environment.backendMajorVersion = null
+      this.environment.hideAdminBanner = false
     }
   },
   methods: {
@@ -316,7 +318,8 @@ export default {
               host: this.environment.host,
               port: parseInt(this.environment.port),
               ssl: this.environment.ssl,
-              backendMajorVersion: this.environment.backendMajorVersion
+              backendMajorVersion: this.environment.backendMajorVersion,
+              hideAdminBanner: this.environment.hideAdminBanner
             }
           })
         } else {
@@ -328,7 +331,12 @@ export default {
               host: this.environment.host,
               port: parseInt(this.environment.port),
               ssl: this.environment.ssl,
-              backendMajorVersion: this.environment.backendMajorVersion
+              backendMajorVersion: this.environment.backendMajorVersion,
+              hideAdminBanner: ['localhost', '127.0.0.1'].includes(
+                this.environment.host
+              )
+                ? true
+                : false
             }
           })
         }

--- a/src/components/Common/Environments/CreateEnvironment.vue
+++ b/src/components/Common/Environments/CreateEnvironment.vue
@@ -127,7 +127,11 @@ import { validationMixin } from 'vuelidate'
 import { numeric, required } from 'vuelidate/lib/validators'
 import { isValidHostname, notIncludeScheme } from '../../../validators'
 
-import { envColors, DEFAULT_COLOR } from '../../../vuex/modules/kuzzle/store'
+import {
+  envColors,
+  DEFAULT_COLOR,
+  NO_ADMIN_WARNING_HOSTS
+} from '../../../vuex/modules/kuzzle/store'
 const useHttps = window.location.protocol === 'https:'
 
 /**
@@ -168,7 +172,7 @@ export default {
         color: null,
         ssl: useHttps,
         backendMajorVersion: null,
-        hideAdminBanner: false
+        hideAdminWarning: false
       },
       submitting: false
     }
@@ -268,7 +272,7 @@ export default {
       this.environment.color = currentEnv.color
       this.environment.ssl = currentEnv.ssl
       this.environment.backendMajorVersion = currentEnv.backendMajorVersion
-      this.environment.hideAdminBanner = currentEnv.hideAdminBanner
+      this.environment.hideAdminWarning = currentEnv.hideAdminWarning
       this.$nextTick(() => this.showValidationErrors())
     } else {
       this.environment.name = null
@@ -277,7 +281,7 @@ export default {
       this.environment.color = DEFAULT_COLOR
       this.environment.ssl = useHttps
       this.environment.backendMajorVersion = null
-      this.environment.hideAdminBanner = false
+      this.environment.hideAdminWarning = false
     }
   },
   methods: {
@@ -319,7 +323,7 @@ export default {
               port: parseInt(this.environment.port),
               ssl: this.environment.ssl,
               backendMajorVersion: this.environment.backendMajorVersion,
-              hideAdminBanner: this.environment.hideAdminBanner
+              hideAdminWarning: this.environment.hideAdminWarning
             }
           })
         } else {
@@ -332,7 +336,7 @@ export default {
               port: parseInt(this.environment.port),
               ssl: this.environment.ssl,
               backendMajorVersion: this.environment.backendMajorVersion,
-              hideAdminBanner: ['localhost', '127.0.0.1'].includes(
+              hideAdminWarning: NO_ADMIN_WARNING_HOSTS.includes(
                 this.environment.host
               )
                 ? true

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -17,8 +17,8 @@
       no-auto-hide
       toaster="b-toaster-bottom-right"
       title="Warning!"
-      data-cy="noAdminAlert"
-      id="no-admin-banner"
+      data-cy="noAdminWarning"
+      id="no-admin-warning"
     >
       <p>
         Your Kuzzle has no administrator user. It is strongly recommended
@@ -30,7 +30,7 @@
           variant="primary"
           size="sm"
           id="noAdminGotIt"
-          @click="hideNoAdminBanner"
+          @click="hideNoAdminWarning"
         >
           Ok, got it
         </b-button>
@@ -79,28 +79,28 @@ export default {
     }
   },
   methods: {
-    hideNoAdminBanner() {
+    hideNoAdminWarning() {
       this.$store.direct.dispatch.kuzzle.updateEnvironment({
         id: this.$store.direct.state.kuzzle.currentId,
         environment: {
           ...this.currentEnvironment,
-          hideAdminBanner: true
+          hideAdminWarning: true
         }
       })
-      this.$bvToast.hide('no-admin-banner')
+      this.$bvToast.hide('no-admin-warning')
     },
     onTokenExpired() {
       this.$store.direct.dispatch.auth.setSession(null)
     },
     noop() {},
-    displayNoAdminToast() {
+    displayNoAdminWarning() {
       if (this.$store.direct.getters.auth.adminAlreadyExists) {
         return
       }
-      if (this.currentEnvironment.hideAdminBanner) {
+      if (this.currentEnvironment.hideAdminWarning) {
         return
       }
-      this.$bvToast.show('no-admin-banner')
+      this.$bvToast.show('no-admin-warning')
     }
   },
   mounted() {
@@ -124,7 +124,7 @@ export default {
         }
       }
     })
-    this.displayNoAdminToast()
+    this.displayNoAdminWarning()
   },
   beforeDestroy() {
     this.$kuzzle.removeListener('tokenExpired')

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -65,10 +65,7 @@ export default {
   computed: {
     ...mapGetters('kuzzle', ['currentEnvironment']),
     displayNoAdminWarning() {
-      return (
-        !this.currentEnvironment.hideAdminWarning &&
-        !this.$store.direct.getters.auth.adminAlreadyExists
-      )
+      return !this.$store.direct.getters.auth.adminAlreadyExists
     }
   },
   methods: {

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -15,7 +15,7 @@
               class="text-center"
               variant="info"
               data-cy="noAdminAlert"
-              :show="!$store.direct.getters.auth.adminAlreadyExists"
+              :show="displayNoAdminBanner"
             >
               <b>Warning!</b> Your Kuzzle has no administrator user. It is
               strongly recommended
@@ -45,6 +45,7 @@
 <script>
 import LoginForm from './Common/Login/Form'
 import EnvironmentSwitch from './Common/Environments/EnvironmentsSwitch'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'Login',
@@ -55,6 +56,15 @@ export default {
   data() {
     return {
       environmentId: null
+    }
+  },
+  computed: {
+    ...mapGetters('kuzzle', ['currentEnvironment']),
+    displayNoAdminBanner() {
+      return (
+        !this.currentEnvironment.hideAdminBanner &&
+        !this.$store.direct.getters.auth.adminAlreadyExists
+      )
     }
   },
   methods: {

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -14,12 +14,16 @@
             <b-alert
               class="text-center"
               variant="info"
-              data-cy="noAdminAlert"
-              :show="displayNoAdminBanner"
+              data-cy="noAdminWarning"
+              :show="displayNoAdminWarning"
             >
               <b>Warning!</b> Your Kuzzle has no administrator user. It is
               strongly recommended
-              <a class="alert-link" data-cy="NoAdminAlert-link" href="#/signup">
+              <a
+                class="alert-link"
+                data-cy="NoAdminWarning-link"
+                href="#/signup"
+              >
                 that you create one.</a
               >
             </b-alert>
@@ -60,9 +64,9 @@ export default {
   },
   computed: {
     ...mapGetters('kuzzle', ['currentEnvironment']),
-    displayNoAdminBanner() {
+    displayNoAdminWarning() {
       return (
-        !this.currentEnvironment.hideAdminBanner &&
+        !this.currentEnvironment.hideAdminWarning &&
         !this.$store.direct.getters.auth.adminAlreadyExists
       )
     }

--- a/src/vuex/modules/kuzzle/store.ts
+++ b/src/vuex/modules/kuzzle/store.ts
@@ -134,7 +134,7 @@ const actions = createActions({
       (payload.environment.host !== getters.currentEnvironment.host ||
         payload.environment.port !== getters.currentEnvironment.port ||
         payload.environment.ssl !== getters.currentEnvironment.ssl ||
-        payload.backendMajorVersion !==
+        payload.environment.backendMajorVersion !==
           getters.currentEnvironment.backendMajorVersion)
     ) {
       mustReconnect = true
@@ -202,8 +202,12 @@ const actions = createActions({
 
     loadedEnv = JSON.parse(localStorage.getItem(LS_ENVIRONMENTS) || '{}')
     Object.keys(loadedEnv).forEach(envName => {
+      const env = loadedEnv[envName]
+      if (env.hideAdminBanner === undefined) {
+        env.hideAdminBanner = ['localhost', '127.0.0.1'].includes(env.host)
+      }
       commit.createEnvironment({
-        environment: loadedEnv[envName],
+        environment: env,
         id: envName
       })
     })

--- a/src/vuex/modules/kuzzle/store.ts
+++ b/src/vuex/modules/kuzzle/store.ts
@@ -135,7 +135,7 @@ const actions = createActions({
       (payload.environment.host !== getters.currentEnvironment.host ||
         payload.environment.port !== getters.currentEnvironment.port ||
         payload.environment.ssl !== getters.currentEnvironment.ssl ||
-        payload.environment.backendMajorVersion !==
+        payload.backendMajorVersion !==
           getters.currentEnvironment.backendMajorVersion)
     ) {
       mustReconnect = true

--- a/src/vuex/modules/kuzzle/store.ts
+++ b/src/vuex/modules/kuzzle/store.ts
@@ -13,6 +13,7 @@ export const state: KuzzleState = {
   online: false,
   errorFromKuzzle: undefined
 }
+export const NO_ADMIN_WARNING_HOSTS = ['localhost', '127.0.0.1']
 
 export const DEFAULT_COLOR = 'darkblue'
 
@@ -203,8 +204,8 @@ const actions = createActions({
     loadedEnv = JSON.parse(localStorage.getItem(LS_ENVIRONMENTS) || '{}')
     Object.keys(loadedEnv).forEach(envName => {
       const env = loadedEnv[envName]
-      if (env.hideAdminBanner === undefined) {
-        env.hideAdminBanner = ['localhost', '127.0.0.1'].includes(env.host)
+      if (env.hideAdminWarning === undefined) {
+        env.hideAdminWarning = NO_ADMIN_WARNING_HOSTS.includes(env.host)
       }
       commit.createEnvironment({
         environment: env,

--- a/test/e2e/cypress/integration/single-backend/environments.spec.js
+++ b/test/e2e/cypress/integration/single-backend/environments.spec.js
@@ -38,7 +38,8 @@ describe('Environments', function() {
           ssl: false,
           port: 7512,
           backendMajorVersion: backendVersion,
-          token: null
+          token: null,
+          hideAdminWarning: true
         }
       })
     )
@@ -114,7 +115,8 @@ describe('Environments', function() {
           ssl: false,
           port: 7512,
           backendMajorVersion: backendVersion || 2,
-          token: null
+          token: null,
+          hideAdminWarning: true
         },
         [envNames[1]]: {
           name: envNames[1],
@@ -123,7 +125,8 @@ describe('Environments', function() {
           ssl: false,
           port: 7512,
           backendMajorVersion: backendVersion || 2,
-          token: null
+          token: null,
+          hideAdminWarning: true
         }
       })
     )
@@ -199,7 +202,8 @@ describe('Environments', function() {
           ssl: false,
           port: 7512,
           backendMajorVersion: backendVersion,
-          token: null
+          token: null,
+          hideAdminWarning: true
         }
       })
     )
@@ -261,7 +265,8 @@ describe('Environments', function() {
           ssl: false,
           port: ports[0],
           backendMajorVersion: backendVersion,
-          token: null
+          token: null,
+          hideAdminWarning: true
         }
       })
     )
@@ -314,7 +319,8 @@ describe('Environments', function() {
           host: 'localhost',
           ssl: false,
           port: 7512,
-          token: null
+          token: null,
+          hideAdminWarning: true
           // missing backendMajorVersion
         }
       })
@@ -329,7 +335,7 @@ describe('Environments', function() {
     })
   })
 
-  it('Should display a spinner when connecting to an unavailable backend and connect automatically whe the backend is up', () => {
+  it.only('Should display a spinner when connecting to an unavailable backend and connect automatically whe the backend is up', () => {
     cy.initLocalEnv(backendVersion)
     cy.task('doco', { version: backendVersion, docoArgs: ['down'] })
     cy.wait(5000)
@@ -386,7 +392,8 @@ describe('Environments', function() {
           color: 'darkblue',
           host: 'localhost',
           ssl: false,
-          port: 7512
+          port: 7512,
+          hideAdminWarning: true
         }
       })
     )
@@ -399,7 +406,7 @@ describe('Environments', function() {
       `v${backendVersion}.x`
     )
     cy.get('[data-cy=Environment-SubmitButton]').click()
-
+    cy.wait(5000)
     cy.url().should('contain', 'login')
   })
 
@@ -447,7 +454,8 @@ describe('Environments', function() {
           ssl: false,
           port: 7512,
           backendMajorVersion: backendVersion,
-          token: null
+          token: null,
+          hideAdminWarning: true
         }
       })
     )
@@ -495,14 +503,13 @@ describe('Import and export environments', function() {
     cy.get('[data-cy="CreateEnvironment-import"]').click()
     cy.contains('Import Connection')
 
-    cy.get('[data-cy="EnvironmentImport-fileInput"]')
-      .attachFile(
-        {
-          filePath: 'environment.json',
-          mimeType: 'application/json'
-        },
-        { subjectType: 'input', force: true }
-      )
+    cy.get('[data-cy="EnvironmentImport-fileInput"]').attachFile(
+      {
+        filePath: 'environment.json',
+        mimeType: 'application/json'
+      },
+      { subjectType: 'input', force: true }
+    )
     cy.get('[data-cy=EnvironmentImport-ok]')
       .should('exist')
       .should('contain', 'Found 2 connections')
@@ -522,14 +529,13 @@ describe('Import and export environments', function() {
     cy.get('[data-cy="CreateEnvironment-import"]').click()
     cy.contains('Import Connection')
 
-    cy.get('[data-cy="EnvironmentImport-fileInput"]')
-      .attachFile(
-        {
-          filePath: 'image.jpg',
-          mimeType: 'image/jpeg'
-        },
-        { subjectType: 'input', force: true }
-      )
+    cy.get('[data-cy="EnvironmentImport-fileInput"]').attachFile(
+      {
+        filePath: 'image.jpg',
+        mimeType: 'image/jpeg'
+      },
+      { subjectType: 'input', force: true }
+    )
     cy.get('[data-cy=EnvironmentImport-err]')
       .should('exist')
       .should('contain', 'Uploaded file type (image/jpeg) is not supported.')
@@ -598,7 +604,7 @@ describe('Import and export environments', function() {
       )
       .should(
         'equal',
-        `{"${newEnvName}":{"name":"${newEnvName}","color":"darkblue","host":"localhost","port":7512,"ssl":false,"backendMajorVersion":${backendVersion}},"${secondEnvName}":{"name":"${secondEnvName}","color":"darkblue","host":"localhost","port":7512,"ssl":false,"backendMajorVersion":${backendVersion}}}`
+        `{"${newEnvName}":{"name":"${newEnvName}","color":"darkblue","host":"localhost","port":7512,"ssl":false,"backendMajorVersion":${backendVersion},"hideAdminWarning":true},"${secondEnvName}":{"name":"${secondEnvName}","color":"darkblue","host":"localhost","port":7512,"ssl":false,"backendMajorVersion":${backendVersion},"hideAdminWarning":true}}`
       )
   })
 })

--- a/test/e2e/cypress/integration/single-backend/login.spec.js
+++ b/test/e2e/cypress/integration/single-backend/login.spec.js
@@ -39,7 +39,7 @@ describe('Login', function() {
     cy.request('POST', 'http://localhost:7512/admin/_resetSecurity')
 
     cy.visit('/')
-    cy.get('[data-cy="NoAdminAlert-link"]').click()
+    cy.get('[data-cy="NoAdminWarning-link"]').click()
     cy.contains('Create an Admin Account')
     cy.get('[data-cy="Signup-username"]').type(admin.username)
     cy.get('[data-cy="Signup-password1"]').type(admin.password)


### PR DESCRIPTION
fix #903 

Add a `hideAdminBanner` in environments (store & localStorage)
Login banner still the same
Layout banner changed to a toast
Add a button to hide the warning for the current environment (both banners & toast will be hided)
Default behavior : 
  - hide for `localhost` and `127.0.0.1` hosts
  - display for others
 