### PR TITLE
Store Current environment in session storage instead of local storage

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,5 +61,5 @@ module.exports = {
     }),
   antiGlitchOverlayTimeout: 900,
   LS_ENVIRONMENTS: 'environments',
-  LS_CURRENT_ENV: 'currentEnvironment'
+  SS_CURRENT_ENV: 'currentEnv'
 }

--- a/src/vuex/modules/kuzzle/store.ts
+++ b/src/vuex/modules/kuzzle/store.ts
@@ -5,7 +5,7 @@ import { moduleActionContext } from '@/vuex/store'
 import { getters } from './getters'
 
 export const LS_ENVIRONMENTS = 'environments'
-export const LS_CURRENT_ENV = 'currentEnv'
+export const SS_CURRENT_ENV = 'currentEnv'
 export const state: KuzzleState = {
   environments: {},
   currentId: undefined,
@@ -86,7 +86,7 @@ const actions = createActions({
   setCurrentEnvironment(context, payload) {
     const { commit } = kuzzleActionContext(context)
 
-    localStorage.setItem(LS_CURRENT_ENV, payload)
+    sessionStorage.setItem(SS_CURRENT_ENV, payload)
     commit.setCurrentEnvironment(payload)
   },
   createEnvironment(context, payload) {
@@ -109,7 +109,7 @@ const actions = createActions({
 
     if (state.currentId === id) {
       dispatch.setCurrentEnvironment(null)
-      localStorage.removeItem(LS_CURRENT_ENV)
+      sessionStorage.removeItem(SS_CURRENT_ENV)
     }
 
     localStorage.setItem(LS_ENVIRONMENTS, JSON.stringify(state.environments))
@@ -213,7 +213,7 @@ const actions = createActions({
       })
     })
 
-    currentId = localStorage.getItem(LS_CURRENT_ENV)
+    currentId = sessionStorage.getItem(SS_CURRENT_ENV)
     commit.setCurrentEnvironment(currentId)
   }
 })

--- a/test/e2e/cypress/integration/multi-backend/switch.spec.js
+++ b/test/e2e/cypress/integration/multi-backend/switch.spec.js
@@ -45,7 +45,7 @@ describe('Switch between two backends', () => {
         }
       })
     )
-    localStorage.setItem('currentEnv', backends[0].name)
+    sessionStorage.setItem('currentEnv', backends[0].name)
 
     cy.visit('/')
     cy.wait(5000)

--- a/test/e2e/cypress/integration/single-backend/environments.spec.js
+++ b/test/e2e/cypress/integration/single-backend/environments.spec.js
@@ -130,7 +130,7 @@ describe('Environments', function() {
         }
       })
     )
-    localStorage.setItem('currentEnv', envNames[0])
+    sessionStorage.setItem('currentEnv', envNames[0])
     cy.visit('/')
     cy.contains('Connected to')
     cy.get('[data-cy="EnvironmentSwitch"]').click()
@@ -180,7 +180,7 @@ describe('Environments', function() {
       force: true
     })
     cy.wait(1000)
-    localStorage.setItem('currentEnv', envName)
+    sessionStorage.setItem('currentEnv', envName)
     cy.visit('/')
     cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
 
@@ -207,7 +207,7 @@ describe('Environments', function() {
         }
       })
     )
-    localStorage.setItem('currentEnv', reachableEnvName)
+    sessionStorage.setItem('currentEnv', reachableEnvName)
 
     cy.visit('/')
     cy.contains('Connected to')
@@ -270,7 +270,7 @@ describe('Environments', function() {
         }
       })
     )
-    localStorage.setItem('currentEnv', envNames[0])
+    sessionStorage.setItem('currentEnv', envNames[0])
     cy.visit('/')
     cy.contains('Connected to')
 
@@ -397,7 +397,7 @@ describe('Environments', function() {
         }
       })
     )
-    localStorage.setItem('currentEnv', envName)
+    sessionStorage.setItem('currentEnv', envName)
     cy.visit('/')
     cy.contains('Edit a Connection')
     cy.contains('You must select a backend version')
@@ -436,7 +436,7 @@ describe('Environments', function() {
       force: true
     })
     cy.wait(1000)
-    localStorage.setItem('currentEnv', 'localEnvTestTabTitle')
+    sessionStorage.setItem('currentEnv', 'localEnvTestTabTitle')
     cy.visit('/')
     cy.get('[data-cy="LoginAsAnonymous-Btn"]').click()
 

--- a/test/e2e/cypress/integration/single-backend/roles.spec.js
+++ b/test/e2e/cypress/integration/single-backend/roles.spec.js
@@ -323,7 +323,7 @@ describe('Roles', () => {
         })
       )
 
-      localStorage.setItem('currentEnv', 'testEnv')
+      sessionStorage.setItem('currentEnv', 'testEnv')
 
       cy.visit('#/security/roles')
 

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -51,7 +51,7 @@ Cypress.Commands.add(
         }
       })
     )
-    localStorage.setItem('currentEnv', envName)
+    sessionStorage.setItem('currentEnv', envName)
   }
 )
 
@@ -91,7 +91,7 @@ Cypress.Commands.add('waitForService', (url, state = 'up', tries = 30) => {
 })
 
 Cypress.Commands.add('skipOnBackendVersion', version => {
-  const currentEnvName = localStorage.getItem('currentEnv')
+  const currentEnvName = sessionStorage.getItem('currentEnv')
   const currentEnv = JSON.parse(localStorage.getItem('environments'))[
     currentEnvName
   ]
@@ -103,7 +103,7 @@ Cypress.Commands.add('skipOnBackendVersion', version => {
 })
 
 Cypress.Commands.add('skipUnlessBackendVersion', version => {
-  const currentEnvName = localStorage.getItem('currentEnv')
+  const currentEnvName = sessionStorage.getItem('currentEnv')
   const currentEnv = JSON.parse(localStorage.getItem('environments'))[
     currentEnvName
   ]


### PR DESCRIPTION
Close #969 

## What does this PR do ?

Store the `currentEnv` in sessionStorage instead of localStorage. This will able us to connect on different environment on same web browser.

