### PR TITLE
Fix the Browse Index `Create collection` button

### DIFF
--- a/src/components/Data/Indexes/Page.vue
+++ b/src/components/Data/Indexes/Page.vue
@@ -257,7 +257,6 @@ export default {
       this.$bvModal.show(this.createIndexModalId)
     },
     openDeleteModal(index) {
-      this.$log.error('IndexesPage::openDeleteModal', index.name)
       this.indexToDelete = index
       this.$bvModal.show(this.deleteIndexModalId)
     },

--- a/src/components/Data/Indexes/Page.vue
+++ b/src/components/Data/Indexes/Page.vue
@@ -133,7 +133,7 @@
               :data-cy="`IndexesPage-browse--${row.item.name}`"
               :to="{
                 name: 'Collections',
-                params: { index: row.item.name }
+                params: { indexName: row.item.name }
               }"
               ><i class="fa fa-eye"></i
             ></b-button>
@@ -144,7 +144,7 @@
               :data-cy="`IndexesPage-createCollection--${row.item.name}`"
               :to="{
                 name: 'CreateCollection',
-                params: { index: row.item.name }
+                params: { indexName: row.item.name }
               }"
               ><i class="fa fa-plus"></i
             ></b-button>
@@ -257,6 +257,7 @@ export default {
       this.$bvModal.show(this.createIndexModalId)
     },
     openDeleteModal(index) {
+      this.$log.error('IndexesPage::openDeleteModal', index.name)
       this.indexToDelete = index
       this.$bvModal.show(this.deleteIndexModalId)
     },


### PR DESCRIPTION


## What does this PR do ?
Currently on https://console.kuzzle.io , there is a bug on the `+` button when you're on the `All indices` view and you want to create a collection to a specific index using this button. For now, it redirects you to a blank page.

Close #967

### How should this be manually tested?

- Open the Admin Console
- Create an index
- On the `All indexes` view try to create collection using this `+` button in Table View
- Now it should redirect you to the collection creation form

