### PR TITLE
Sort environment selector by alphabetical order

### DIFF
--- a/src/components/Common/Environments/EnvironmentsSwitch.vue
+++ b/src/components/Common/Environments/EnvironmentsSwitch.vue
@@ -22,7 +22,7 @@
       </template>
     </template>
     <b-dropdown-item
-      v-for="(env, index) in $store.direct.getters.kuzzle.environments"
+      v-for="(env, index) in sortEnv($store.direct.getters.kuzzle.environments)"
       class="EnvironmentSwitch-env environment"
       :key="env.name"
       :data-cy="`EnvironmentSwitch-env_${formatForDom(env.name)}`"
@@ -122,6 +122,14 @@ export default {
           this.$store.direct.dispatch.kuzzle.onConnectionError(error)
         }
       }
+    },
+    sortEnv(envObject) {
+      return Object.keys(envObject)
+        .sort()
+        .reduce(function(result, key) {
+          result[key] = envObject[key]
+          return result
+        }, {})
     },
     formatForDom
   }

--- a/src/components/Common/Environments/EnvironmentsSwitch.vue
+++ b/src/components/Common/Environments/EnvironmentsSwitch.vue
@@ -22,7 +22,9 @@
       </template>
     </template>
     <b-dropdown-item
-      v-for="(env, index) in sortEnv($store.direct.getters.kuzzle.environments)"
+      v-for="(env, index) in sortObject(
+        $store.direct.getters.kuzzle.environments
+      )"
       class="EnvironmentSwitch-env environment"
       :key="env.name"
       :data-cy="`EnvironmentSwitch-env_${formatForDom(env.name)}`"
@@ -75,7 +77,7 @@
 </template>
 
 <script>
-import { formatForDom } from '../../../utils'
+import { formatForDom, sortObject } from '../../../utils'
 import { mapValues, omit } from 'lodash'
 import { isValidEnvironment } from '../../../validators'
 import { mapGetters } from 'vuex'
@@ -123,14 +125,7 @@ export default {
         }
       }
     },
-    sortEnv(envObject) {
-      return Object.keys(envObject)
-        .sort()
-        .reduce(function(result, key) {
-          result[key] = envObject[key]
-          return result
-        }, {})
-    },
+    sortObject,
     formatForDom
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ module.exports = {
   sortObject(object) {
     return Object.keys(object)
       .sort()
-      .reduce(function(result, key) {
+      .reduce((result, key) => {
         result[key] = object[key]
         return result
       }, {})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,14 @@ module.exports = {
   formatForDom: word => {
     return word.replace(/[!"#$%&'()*+,./:;<=>?@[\]^`{|}~ ]/g, '-')
   },
+  sortObject(object) {
+    return Object.keys(object)
+      .sort()
+      .reduce(function(result, key) {
+        result[key] = object[key]
+        return result
+      }, {})
+  },
   truncateName: (name, maxLength = 50) => {
     if (!name) {
       return ''


### PR DESCRIPTION
## Sort environment selector by alphabecital order
result 
![image](https://user-images.githubusercontent.com/78204354/226404401-68f08782-724f-4b1d-966f-55d4e36ba01e.png)


### How should this be manually tested?

  - Step 1 : clone and run
  - Step 2 : try to create new connections and check their order



