### PR TITLE
Update dockerfile & compose to run the admin console project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,54 @@
-FROM kuzzleio/kuzzle-runner:12 as build-stage
+FROM kuzzleio/kuzzle-runner:12 AS build-stage
 WORKDIR /app
 COPY package*.json ./
 RUN NODE_ENV=production npm install
 COPY . .
 RUN npm run build
 
+# security stage
+FROM alpine:latest AS security-stage
+ARG DOMAIN_NAME=localhost
+ARG DAYS_VALID=180
+
+RUN apk add --no-cache openssl
+RUN echo "Creating self-signed certificate valid for ${DAYS_VALID} days for domain ${DOMAIN_NAME}" && \
+    openssl \
+    req -x509 \
+    -nodes \
+    -subj "/CN=${DOMAIN_NAME}" \
+    -addext "subjectAltName=DNS:${DOMAIN_NAME}" \
+    -days ${DAYS_VALID} \
+    -newkey rsa:2048 -keyout /tmp/self-signed.key \
+    -out /tmp/self-signed.crt
+
 # production stage
-FROM nginx:stable-alpine as production-stage
+FROM nginx:stable-alpine AS production-stage
+ARG DOMAIN_NAME=localhost
 COPY --from=build-stage /app/dist /usr/share/nginx/html
+COPY --from=security-stage /tmp/self-signed.key /etc/ssl/private
+COPY --from=security-stage /tmp/self-signed.crt /etc/ssl/certs
+COPY <<EOF /etc/nginx/conf.d/default.conf
+server {
+    listen       80;
+    listen  [::]:80;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    ssl_certificate /etc/ssl/certs/self-signed.crt;
+    ssl_certificate_key /etc/ssl/private/self-signed.key;
+    server_name $DOMAIN_NAME;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page  404              /404.html;
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+EOF
 EXPOSE 80
+EXPOSE 443
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,12 @@
 version: "3"
 
 services:
-  kuzzle:
-    image: kuzzleio/kuzzle-runner:14
-    command: node -e '(new (require("kuzzle").Backend)()).start();'
-    volumes:
-      - .:/var/app
+  kuzzle-admin-console:
+    build:
+      context: .
+      args:
+        DOMAIN_NAME: "localhost"
+        DAYS_VALID: 180
     ports:
-      - "7512:7512"
-    depends_on:
-      - redis
-    environment:
-      - kuzzle_services__storageEngine__client__node=http://elasticsearch:9200
-      - kuzzle_services__storageEngine__commonMapping__dynamic=true
-      - kuzzle_services__internalCache__node__host=redis
-      - kuzzle_services__memoryStorage__node__host=redis
-      - DEBUG=${DEBUG:-none}
-
-  redis:
-    image: redis:5
-
-  elasticsearch:
-    image: kuzzleio/elasticsearch:7
-    environment:
-      - ingest.geoip.downloader.enabled=false
-    ulimits:
-      nofile: 65536
+      - "8080:80"
+      - "8443:443"


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle-admin-console/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

It updates the Docker related items so that docker compose can be used to run this project instead of it running a Kuzzle instance.

I did this for my own purposes however it seems useful for any other users. If you'd like to keep the existing Docker files then I have no issue with this being rejected.

<!--
  Please include a summary of the change, relevant motivation and context.
  Also, list any dependencies that are required for this change.
-->

### How should this be manually tested?

<!--
  Please describe your test configuration, the tests ran to verify your changes
  And give us instructions on how to reproduce them.
-->
  - Step 1 : In console run `docker compose up -d`, include `--build` if you'd like to force a rebuild
  - Step 2 : Navigate to the default ports of the [HTTP](http://localhost:8080) or [HTTPS](https://localhost:8443) site
  - Step 3 : You should now be able to access the Kuzzle admin console via docker without any additional effort