### PR TITLE
fix: update btn trigger replace instead of update

### DIFF
--- a/src/components/Data/Documents/Common/CreateOrUpdate.vue
+++ b/src/components/Data/Documents/Common/CreateOrUpdate.vue
@@ -83,7 +83,7 @@
             variant="primary"
             class="ml-2"
             :disabled="submitting || !isDocumentValid"
-            @click="submit"
+            @click="submit()"
           >
             <i class="fa fa-plus-circle left" />
             Create
@@ -94,7 +94,7 @@
             class="ml-2"
             data-cy="DocumentUpdate-btn"
             :disabled="submitting || !isDocumentValid"
-            @click="submit"
+            @click="submit()"
           >
             <i class="fa fa-pencil-alt left" />
             Update


### PR DESCRIPTION
## What does this PR do ?

Fix the udpate button to call update function.

Before this fix when you were updating a document it was calling replace function so all metadatas were overwritten.

### How should this be manually tested?

  - Step 1 : Update a document with an author that's not you
  - Step 2 : Field author in _kuzzle_info should not be changed to your user