### PR TITLE
feat: fetch Kuzzle Application OpenAPI specs to prefill documented options

### DIFF
--- a/src/components/ApiAction.vue
+++ b/src/components/ApiAction.vue
@@ -308,11 +308,17 @@ export default {
     },
     async getKuzzleOpenApi() {
       try {
-        const openApi = await this.$kuzzle.query({
+        const openApiKuzzle = await this.$kuzzle.query({
           controller: 'server',
           action: 'openapi',
+          scope: 'kuzzle',
         });
-        this.openapi = openApi.paths;
+        const openApiApp = await this.$kuzzle.query({
+          controller: 'server',
+          action: 'openapi',
+          scope: 'app',
+        });
+        this.openapi = { ...openApiApp.paths, ...openApiKuzzle.paths };
       } catch (error) {
         this.$log.error(error);
         this.$bvToast.toast(

--- a/src/components/ApiAction/QueryCard.vue
+++ b/src/components/ApiAction/QueryCard.vue
@@ -254,7 +254,7 @@ export default {
             case 'string':
               query.body[key] = '';
               break;
-            case 'number':
+            case 'number' || 'integer':
               query.body[key] = 0;
               break;
             case 'boolean':
@@ -262,6 +262,9 @@ export default {
               break;
             case 'array':
               query.body[key] = [];
+              break;
+            case 'object':
+              query.body[key] = {};
               break;
             default:
               query.body[key] = '';

--- a/src/components/ApiAction/QueryCard.vue
+++ b/src/components/ApiAction/QueryCard.vue
@@ -230,7 +230,7 @@ export default {
         const obj = {
           controller: query.controller,
           action: query.action,
-          body: query.body,
+          body: {},
         };
         this.jsonQuery = JSON.stringify(obj, null, 2);
         this.$refs[`queryEditorWrapper-${this.tabIdx}`].setContent(this.jsonQuery);
@@ -244,6 +244,28 @@ export default {
       if (params) {
         for (const param of params) {
           query[param.name] = '';
+        }
+      }
+      const body = _.get(this.openapi, `${openApiPath}.${verb}.requestBody`, null);
+      if (body && body.content['application/json']) {
+        const prefilledBody = body.content['application/json'].schema.properties;
+        for (const key of Object.keys(prefilledBody)) {
+          switch (prefilledBody[key].type) {
+            case 'string':
+              query.body[key] = '';
+              break;
+            case 'number':
+              query.body[key] = 0;
+              break;
+            case 'boolean':
+              query.body[key] = false;
+              break;
+            case 'array':
+              query.body[key] = [];
+              break;
+            default:
+              query.body[key] = '';
+          }
         }
       }
       this.jsonQuery = JSON.stringify(query, null, 2);


### PR DESCRIPTION


<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle-admin-console/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

For now the APIAction view prefill only native API routes options. This PR make it able to fetch the application developer OpenAPI documentation to perform the same behavior with custom API routes 

### How should this be manually tested?

https://github.com/user-attachments/assets/8c75b86e-f4a2-42bc-868b-1d8807eb155c


