### PR TITLE
feat: custom fields in colview, KOpenAPI for documented options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "vue-color": "^2.8.1",
         "vue-form-generator": "^2.3.4",
         "vue-multipane": "^0.9.5",
-        "vue-multiselect": "^3.1.0",
+        "vue-multiselect": "^2.1.7",
         "vue-router": "^3.6.5",
         "vue2-leaflet": "^2.7.1",
         "vuedraggable": "^2.24.3",
@@ -18862,13 +18862,13 @@
       }
     },
     "node_modules/vue-multiselect": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-3.1.0.tgz",
-      "integrity": "sha512-+i/fjTqFBpaay9NP+lU7obBeNaw2DdFDFs4mqhsM0aEtKRdvIf7CfREAx2o2B4XDmPrBt1r7x1YCM3BOMLaUgQ==",
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.9.tgz",
+      "integrity": "sha512-nGEppmzhQQT2iDz4cl+ZCX3BpeNhygK50zWFTIRS+r7K7i61uWXJWSioMuf+V/161EPQjexI8NaEBdUlF3dp+g==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.1",
-        "npm": ">= 6.14.15"
+        "node": ">= 4.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "vue-color": "^2.8.1",
     "vue-form-generator": "^2.3.4",
     "vue-multipane": "^0.9.5",
-    "vue-multiselect": "^3.1.0",
+    "vue-multiselect": "^2.1.7",
     "vue-router": "^3.6.5",
     "vue2-leaflet": "^2.7.1",
     "vuedraggable": "^2.24.3",

--- a/src/components/ApiAction.vue
+++ b/src/components/ApiAction.vue
@@ -308,11 +308,17 @@ export default {
     },
     async getKuzzleOpenApi() {
       try {
-        const openApi = await this.$kuzzle.query({
+        const openApiKuzzle = await this.$kuzzle.query({
           controller: 'server',
           action: 'openapi',
+          scope: 'kuzzle',
         });
-        this.openapi = openApi.paths;
+        const openApiApp = await this.$kuzzle.query({
+          controller: 'server',
+          action: 'openapi',
+          scope: 'app',
+        });
+        this.openapi = { ...openApiApp.paths, ...openApiKuzzle.paths };
       } catch (error) {
         this.$log.error(error);
         this.$bvToast.toast(

--- a/src/components/ApiAction/QueryCard.vue
+++ b/src/components/ApiAction/QueryCard.vue
@@ -230,7 +230,7 @@ export default {
         const obj = {
           controller: query.controller,
           action: query.action,
-          body: query.body,
+          body: {},
         };
         this.jsonQuery = JSON.stringify(obj, null, 2);
         this.$refs[`queryEditorWrapper-${this.tabIdx}`].setContent(this.jsonQuery);
@@ -244,6 +244,31 @@ export default {
       if (params) {
         for (const param of params) {
           query[param.name] = '';
+        }
+      }
+      const body = _.get(this.openapi, `${openApiPath}.${verb}.requestBody`, null);
+      if (body && body.content['application/json']) {
+        const prefilledBody = body.content['application/json'].schema.properties;
+        for (const key of Object.keys(prefilledBody)) {
+          switch (prefilledBody[key].type) {
+            case 'string':
+              query.body[key] = '';
+              break;
+            case 'number' || 'integer':
+              query.body[key] = 0;
+              break;
+            case 'boolean':
+              query.body[key] = false;
+              break;
+            case 'array':
+              query.body[key] = [];
+              break;
+            case 'object':
+              query.body[key] = {};
+              break;
+            default:
+              query.body[key] = '';
+          }
         }
       }
       this.jsonQuery = JSON.stringify(query, null, 2);

--- a/src/components/Data/Documents/Views/Column/Column.vue
+++ b/src/components/Data/Documents/Views/Column/Column.vue
@@ -1,52 +1,35 @@
 <template>
   <div class="Column" data-cy="DocumentList-Column">
     <div class="d-flex flex-row align-items-center">
-      <div class="flex-grow-1">
-        <b-dropdown
-          class="mr-2"
-          data-cy="SelectField"
-          variant="outline-secondary"
-          menu-class="dropdownScroll"
-          text="Fields"
-          no-flip
+      <div class="flex-grow-1 d-flex align-items-stretch">
+        <div class="d-inline-block mr-2 w-full max-w-24rem">
+          <multiselect
+            v-model="selectedFieldsComputed"
+            :options="dropdownFields.map((field) => field.text)"
+            :taggable="true"
+            tag-placeholder="Add custom field"
+            placeholder="Select fields"
+            :multiple="true"
+            :close-on-select="false"
+            :allow-empty="true"
+            @tag="addCustomField"
+          />
+        </div>
+        <b-button
+          variant="outline-dark"
+          class="mr-2 align-self-center"
+          @click="$emit('toggle-all')"
         >
-          <b-dropdown-item-button
-            v-if="selectedFields.length !== 0"
-            class="pl-4"
-            @click="resetColumns"
-          >
-            Unselect all
-          </b-dropdown-item-button>
-          <b-dropdown-text
-            v-for="field of dropdownFields"
-            :key="`dropdown-${field.text}`"
-            class="dropdown-text inlineDisplay pointer p-0"
-          >
-            <span class="inlineDisplay-item">
-              <b-form-checkbox
-                :id="field.text"
-                class="mx-2"
-                :checked="field.displayed"
-                :data-cy="`SelectField--${field.text}`"
-                @change="toggleColumn(field.text, $event)"
-              />
-            </span>
-            <label class="inlineDisplay-item code pointer" :for="field.text" :title="field.text">{{
-              field.text
-            }}</label>
-          </b-dropdown-text>
-          <b-dropdown-item v-if="dropdownFields.length === 0">
-            <span class="inlineDisplay-item"> No searchable field </span>
-          </b-dropdown-item>
-        </b-dropdown>
-        <b-button variant="outline-dark" class="mr-2" @click="$emit('toggle-all')">
           <i :class="`far ${allChecked ? 'fa-check-square' : 'fa-square'} left`" />
           Toggle all
+        </b-button>
+        <b-button variant="outline-secondary" class="mr-2 align-self-center" @click="resetColumns">
+          Reset
         </b-button>
 
         <b-button
           variant="outline-danger"
-          class="mr-2"
+          class="mr-2 align-self-center"
           :disabled="!bulkDeleteEnabled"
           @click="$emit('bulk-delete')"
         >
@@ -56,7 +39,7 @@
 
         <b-button
           variant="outline-secondary"
-          class="mr-2"
+          class="mr-2 align-self-center"
           data-cy="Column-btnExportCSV"
           title="Export columns to CSV"
           @click.prevent="displayModalExportCSV"
@@ -236,6 +219,8 @@ import NewDocumentsBadge from '@/components/Data/Documents/Common/NewDocumentsBa
 import HeaderTableView from './HeaderTableView.vue';
 import HighlightableRow from './HighlightableRow.vue';
 import TableCell from './TableCell.vue';
+import Multiselect from 'vue-multiselect';
+import {} from 'vue-multiselect/dist/vue-multiselect.min.css';
 
 export default {
   name: 'Column',
@@ -249,6 +234,7 @@ export default {
     TableCell,
     HighlightableRow,
     NewDocumentsBadge,
+    Multiselect,
   },
   props: {
     searchQuery: Object,
@@ -355,6 +341,14 @@ export default {
     fieldList() {
       return Object.keys(this.flatMapping);
     },
+    selectedFieldsComputed: {
+      get() {
+        return this.selectedFields;
+      },
+      set(value) {
+        this.selectedFields.splice(0, this.selectedFields.length, ...value);
+      },
+    },
   },
   watch: {
     $route: {
@@ -404,7 +398,7 @@ export default {
       };
     },
     resetColumns() {
-      this.selectedFields = [];
+      this.selectedFields.splice(0, this.selectedFields.length);
     },
     truncateName,
     isChecked(id) {
@@ -420,12 +414,10 @@ export default {
     initSelectedFields() {
       this.selectedFields = get(this.collectionSettings, 'columnView.fields', []);
     },
-    toggleColumn(field, value) {
-      if (value && !this.selectedFields.includes(field)) {
-        this.selectedFields.push(field);
-      }
-      if (!value) {
-        this.$delete(this.selectedFields, this.selectedFields.indexOf(field));
+    addCustomField(newField) {
+      const trimmedField = newField.trim();
+      if (trimmedField && !this.selectedFields.includes(trimmedField)) {
+        this.selectedFields.push(trimmedField);
       }
     },
     toggleJsonFormatter(id) {
@@ -501,5 +493,13 @@ export default {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
     'Noto Sans', 'Liberation Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
+}
+
+.multiselect__option--selected.multiselect__option--highlight {
+  background: #e64472 !important;
+}
+
+.max-w-24rem {
+  max-width: 24rem;
 }
 </style>


### PR DESCRIPTION
`feat: add multiselect and custom fields in column view`
## What does this PR do ?

This PR adds a multiselect in column view, allowing to select indexed and non-indexed (custom) fields. Also added a `reset` button to unselect all.

https://github.com/user-attachments/assets/c5ff5ae8-2907-414c-a759-0bc76a84ca63

Linked to [KZLPRD-72](https://kuzzle.atlassian.net/browse/KZLPRD-72).

[KZLPRD-72]: https://kuzzle.atlassian.net/browse/KZLPRD-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


`feat: fetch Kuzzle Application OpenAPI specs to prefill documented options`
## What does this PR also do ?

For now the APIAction view prefill only native API routes options. This PR make it able to fetch the application developer OpenAPI documentation to perform the same behavior with custom API routes 

### How should this be manually tested?

https://github.com/user-attachments/assets/8c75b86e-f4a2-42bc-868b-1d8807eb155c


