### PR TITLE
fix(roles): use new endpoint for restricting default rights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "eslint-plugin-cypress": "3.5.0",
         "eslint-plugin-vue-kuzzle": "0.0.13",
         "file-loader": "6.2.0",
-        "kuzzle": "2.52.0",
+        "kuzzle": "2.55.0",
         "rollup-plugin-visualizer": "5.14.0",
         "sass": "1.86.3",
         "ts-mock-imports": "1.3.16",
@@ -12397,9 +12397,9 @@
       }
     },
     "node_modules/kuzzle": {
-      "version": "2.52.0",
-      "resolved": "https://registry.npmjs.org/kuzzle/-/kuzzle-2.52.0.tgz",
-      "integrity": "sha512-B2KkGPUc5hhLiaAjsc80vB4yXuPaDc+r1S+vpDQwLuErg9jp1BZya6P+bKKQuAFSfqPsvXay+gVaCEUCNbWMfQ==",
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/kuzzle/-/kuzzle-2.55.0.tgz",
+      "integrity": "sha512-ZA/R1rwW7EX91dmT8+TkrfVZHQ+sSOWgi3PqfKpqtaZOEKH8KRi8ufv2lwhmq7cmtbu7jWHMxxHarogRlLv0AA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-cypress": "3.5.0",
     "eslint-plugin-vue-kuzzle": "0.0.13",
     "file-loader": "6.2.0",
-    "kuzzle": "2.52.0",
+    "kuzzle": "2.55.0",
     "rollup-plugin-visualizer": "5.14.0",
     "sass": "1.86.3",
     "ts-mock-imports": "1.3.16",

--- a/src/components/Security/Roles/Page.vue
+++ b/src/components/Security/Roles/Page.vue
@@ -84,70 +84,28 @@ export default {
   methods: {
     async revokeAnonymous() {
       try {
-        await this.$kuzzle.security.updateRole(
-          'anonymous',
-          {
-            controllers: {
-              '*': {
-                actions: {
-                  '*': false,
-                },
-              },
-              auth: {
-                actions: {
-                  checkToken: true,
-                  getCurrentUser: true,
-                  getMyRights: true,
-                  login: true,
-                },
-              },
-              server: {
-                actions: {
-                  publicApi: true,
-                  openapi: true,
-                },
-              },
-            },
-          },
-          { refresh: 'wait_for' },
-        );
-
-        await this.$kuzzle.security.updateRole(
-          'default',
-          {
-            controllers: {
-              '*': {
-                actions: {
-                  '*': false,
-                },
-              },
-              auth: {
-                actions: {
-                  checkToken: true,
-                  getCurrentUser: true,
-                  getMyRights: true,
-                  logout: true,
-                  updateSelf: true,
-                },
-              },
-              server: {
-                actions: {
-                  publicApi: true,
-                },
-              },
-            },
-          },
-          { refresh: 'wait_for' },
-        );
+        await this.$kuzzle.query({
+          controller: 'security',
+          action: 'restrictDefaultRights',
+        });
         this.$router.go(this.$router.currentRoute);
       } catch (err) {
-        this.$log.error(err);
-        this.$bvToast.toast('The complete error has been printed to the console.', {
-          title: 'Ooops! Something went wrong while revoking Anonymous role.',
-          variant: 'danger',
-          toaster: 'b-toaster-bottom-right',
-          appendToast: true,
-        });
+        if (err.status === 404) {
+          this.$bvToast.toast('This action is not supported by your Kuzzle version. You might need to upgrade.', {
+            title: 'Not supported!',
+            variant: 'warning',
+            toaster: 'b-toaster-bottom-right',
+            appendToast: true,
+          });
+        } else {
+          this.$log.error(err);
+          this.$bvToast.toast('The complete error has been printed to the console.', {
+            title: 'Ooops! Something went wrong while revoking Anonymous role.',
+            variant: 'danger',
+            toaster: 'b-toaster-bottom-right',
+            appendToast: true,
+          });
+        }
       }
     },
   },


### PR DESCRIPTION
Remove revoke anonymous rights button in the admin console. This button was manually editing roles causing issues on some deployments. Instead, the backend should expose a `removeAnonymousRights` action.

The remove anonymous rights during the creation of the first admin is still here because it's handled by the backend.