### PR TITLE
fix(ci): keep the dev web service out of the default compose profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ To build the Kuzzle Admin Console on your computer, follow these instructions:
 - `npm run build` : (build the Admin Console)
 - Serve the `dist` directory via your favorite HTTP server (e.g. `http-server dist`)
 - Access the served files in your favorite browser
+
+## Local development stack
+
+A Docker Compose stack (Kuzzle, Elasticsearch, Redis) is provided to develop against a local backend:
+
+```sh
+docker compose up --wait                # backend services only
+npm ci && docker compose --profile dev up  # backend services + the Admin Console dev server on http://localhost:8080
+```
+
+The `web` service is behind the `dev` profile: it mounts the repository into the container, so dependencies must be installed on the host (`npm ci`) before starting it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 services:
+  # Development only: requires dependencies to be installed beforehand
+  # (`npm ci`) since node_modules is mounted from the host.
+  # Start it with `docker compose --profile dev up`.
   web:
+    profiles:
+      - dev
     image: kuzzleio/kuzzle-runner:22
     command: npm run dev --prefix /var/app/ -- --host
     ports:


### PR DESCRIPTION
## What does this PR do ?

Fixes the `E2E Cypress tests` job on `master`, which has been failing at the `Start Kuzzle` step since #1014 was merged ([failing run](https://github.com/kuzzleio/kuzzle-admin-console/actions/runs/30638435406/job/91182263500)):

```
container kuzzle-admin-console-web-1 exited (127)
##[error]Process completed with exit code 1.
```

The `web` service introduced in #1014 mounts the repository into the container (`.:/var/app`) and runs `npm run dev`. In `push_master.workflow.yml` there is no `npm ci` before the `Start Kuzzle` step — dependencies are installed later by `cypress-io/github-action` — so `node_modules` is missing in the mounted volume and the container exits immediately:

```
> vite --host
sh: 1: vite: not found
```

`docker compose up --wait` fails as soon as one of the containers exits, which fails the whole job.

This PR moves the `web` service behind a `dev` Compose profile, so it is only started explicitly and never by `docker compose up --wait`.

Side effect: it also frees port `8080` in the `pull_request` / `push_dev` workflows. Those workflows do run `npm ci` before the Compose step, so the `web` container was starting and publishing the dev server on `8080`; the `vite preview` server started right after fell back to another port, and Cypress was actually running against the container's dev server instead of the production build.

### How should this be manually tested?

- Step 1 : `docker compose config --services` → only `redis`, `elasticsearch`, `kuzzle` (no `web`).
- Step 2 : `docker compose --profile dev config --services` → the four services, including `web`.
- Step 3 : `npm ci && docker compose --profile dev up`, then open http://localhost:8080 — the dev server still works as before.
- Step 4 : CI on this branch reaches the `Cypress run` step instead of failing on `Start Kuzzle`.

### Other changes

- `README.md`: new "Local development stack" section documenting the `dev` profile and the `npm ci` prerequisite (`node_modules` comes from the host).

### Boyscout

- Added a comment in `docker-compose.yml` explaining why the `web` service needs dependencies installed on the host.
