### PR TITLE
ci: align the master e2e job with the dev/PR workflows

### DIFF
--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -27,29 +27,147 @@ jobs:
         uses: ./.github/actions/lint
 
   e2e-tests:
-    name: E2E Cypress tests
+    name: E2E Test - ${{ matrix.spec }}
     needs: ['lint']
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        spec:
+          - login
+          - users
+          - roles
+          - profiles
+          - resetpassword
+          - JSONEditor
+          - chartView
+          - formView
+          - treeview
+          - '404'
+          - api-actions
+          - collections
+          - docs
+          - environments
+          - indexes
+          - search
+          - watch
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Cache Cypress binary
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-binary-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Start Kuzzle
-        run: docker compose up --wait
+        run: |
+          docker compose up --wait
+          docker ps
+          curl -v http://localhost:7512/_healthcheck
 
-      - name: Cypress run
-        uses: cypress-io/github-action@v6
-        with:
-          build: npm run build
-          start: npm run preview
-          browser: chrome
+      - name: Build
+        run: npm run build
 
-      - name: Upload screenshots
+      - name: Start preview server
+        run: |
+          npx vite preview --host 0.0.0.0 --port 8080 &
+          echo $! > preview.pid
+
+          echo "Waiting for preview server..."
+          timeout=30
+          until curl -s http://localhost:8080 > /dev/null; do
+            sleep 1
+            timeout=$((timeout-1))
+            if [ $timeout -eq 0 ]; then
+              echo "Preview server failed to start"
+              exit 1
+            fi
+          done
+          echo "Preview server is ready!"
+
+      - name: Run Cypress test
+        id: cypress
+        run: |
+          START_TIME=$(date +%s)
+
+          npx cypress run \
+            --spec "test/e2e/cypress/integration/single-backend/${{ matrix.spec }}.spec.js" \
+            --browser chrome \
+            --config baseUrl=http://localhost:8080,retries=2
+
+          END_TIME=$(date +%s)
+          DURATION=$((END_TIME - START_TIME))
+          echo "duration=$DURATION" >> $GITHUB_OUTPUT
+
+      - name: Cleanup
+        if: always()
+        run: |
+          if [ -f preview.pid ]; then
+            kill $(cat preview.pid) || true
+          fi
+
+      - name: Upload test results
+        if: always()
         uses: actions/upload-artifact@v4
-        if: failure()
         with:
-          name: cypress-snapshots
+          name: cypress-results-${{ matrix.spec }}
+          path: |
+            cypress/videos
+            cypress/screenshots
+            cypress/results
+          retention-days: 5
+
+      - name: Upload failure screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-snapshots-${{ matrix.spec }}
           path: test/e2e/failed-test
+          retention-days: 5
+
+  test-summary:
+    name: Tests Summary
+    needs: [lint, e2e-tests]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create Summary
+        run: |
+          echo "# Test Results Summary 📊" >> $GITHUB_STEP_SUMMARY
+          echo "## Status" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ needs.e2e-tests.result }}" = "success" ] && [ "${{ needs.lint.result }}" = "success" ]; then
+            echo "✅ All tests passed successfully!" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ Some tests failed" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "## Details" >> $GITHUB_STEP_SUMMARY
+          echo "- Lint: ${{ needs.lint.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- E2E Tests: ${{ needs.e2e-tests.result }}" >> $GITHUB_STEP_SUMMARY
+
+          # Set exit code based on test results
+          if [ "${{ needs.e2e-tests.result }}" = "failure" ]; then
+            echo "❌ E2E tests failed"
+            exit 1
+          elif [ "${{ needs.lint.result }}" = "failure" ]; then
+            echo "❌ Lint failed"
+            exit 1
+          else
+            echo "✅ All tests passed!"
+          fi
 
   deploy-production:
     name: Deploy Admin Console to production - console.kuzzle.io


### PR DESCRIPTION
## What does this PR do ?

Makes the `master` push workflow run its e2e tests exactly like the `pull_request` and `push_dev` workflows do.

`push_master.workflow.yml` was the only workflow left running the whole Cypress suite in one `cypress-io/github-action` invocation, **without retries**. The two others run **one job per spec** with `--config retries=2`. Consequence: a single flaky test fails master and blocks the production deploy, while the very same specs are green on the pull request that was just merged.

That is exactly what happened on 0c8d04c3 ([run](https://github.com/kuzzleio/kuzzle-admin-console/actions/runs/30639982514/job/91187447987)) — 2 failures out of 140 tests:

- `profiles.spec.js:155` — `Expected to find element: [data-cy="ProfileCreateOrUpdate-id"], but never found it` (60s timeout)
- `users.spec.js:101` — `Expected to find content: 'dummy' but never did` (60s timeout)

In both cases the `cypress-snapshots` artifact shows the application stuck on the static loading screen of `index.html` ("Loading the Kuzzle Admin Console. Please wait."), so the Vue app never finished mounting. Both routes are exercised successfully by the other tests of the same spec files (17 of the 18 `users.spec.js` tests pass), and `E2E Test - profiles` / `E2E Test - users` were green on #1015.

The `e2e-tests` job is now byte-for-byte identical to the one in `push_dev.workflow.yml` (matrix of the 17 specs, Cypress binary cache, `npm ci`, explicit build + `vite preview`, `retries=2`, per-spec artifacts), plus the same `Tests Summary` job. `deploy-production` is unchanged and still gated on `e2e-tests`, which now means all 17 matrix jobs.

### How should this be manually tested?

- Step 1 : check that the `e2e-tests` job definition is identical to the one in `push_dev.workflow.yml`.
- Step 2 : after merge, the master run shows 17 `E2E Test - <spec>` jobs instead of a single `E2E Cypress tests` job.
- Step 3 : the production deploy only starts once all 17 jobs are green.

### Other changes

- Adds the `Tests Summary` job already present in the dev workflow, for a readable run summary.

### Boyscout

- Failure screenshots are now uploaded per spec (`cypress-snapshots-<spec>`), which makes them much easier to locate than a single mixed artifact.
